### PR TITLE
chore(ci): move release actions to Node 24

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
       !contains(github.event.head_commit.message, '[no release]')
     steps:
       - name: Checkout
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
@@ -96,7 +96,7 @@ jobs:
           mv "/tmp/$ARCHIVE_NAME" .
 
       - name: Create Release
-        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:
           tag_name: ${{ steps.version.outputs.version }}
           name: Settings ${{ steps.version.outputs.version }}


### PR DESCRIPTION
## Summary

- pin actions/checkout v7.0.1 by its exact commit SHA
- pin softprops/action-gh-release v3.0.2 by its exact commit SHA
- remove the Node.js 20 deprecation annotations observed in release run 31370645768

Both releases declare `using: node24` in their official `action.yml`; mutable action references remain at zero.
