### PR TITLE
fix(ci): stop putting the release token in the push URL

### DIFF
--- a/.gitea/workflows/release.yml
+++ b/.gitea/workflows/release.yml
@@ -108,10 +108,19 @@ jobs:
           git config user.name "CI Bot"
           git config user.email "ci@jiun.dev"
           git tag -a "$VERSION" -m "Release $VERSION"
+
           # `origin` is the read-only Gitea mirror, so push to GitHub explicitly.
-          # The URL carries the token, so keep it out of argv-visible output.
-          git push "https://x-access-token:${GH_TOKEN}@github.com/jiunbae/settings.git" \
-            "refs/tags/$VERSION" >/dev/null 2>&1
+          # The token goes in a credentials file rather than the remote URL: a
+          # URL-embedded token is visible in the container's process list for the
+          # duration of the push, and it forces the whole command to be silenced
+          # to keep it out of the log — which throws away the reason a failed
+          # push failed. With the helper, stderr can flow normally.
+          CRED_DIR="$(mktemp -d)"
+          trap 'rm -rf -- "$CRED_DIR"' EXIT
+          umask 077
+          printf 'https://x-access-token:%s@github.com\n' "$GH_TOKEN" > "$CRED_DIR/creds"
+          git -c "credential.helper=store --file=$CRED_DIR/creds" \
+            push "https://github.com/jiunbae/settings.git" "refs/tags/$VERSION"
           echo "pushed tag $VERSION to github.com/jiunbae/settings"
 
       - name: Create bundled installer


### PR DESCRIPTION
Two defects in the tag-push step I added, both of which matter more now that
GH_RELEASE_TOKEN is actually set and this workflow cuts a release on every
push to master:

  * The comment claimed the token was kept "out of argv-visible output" while
    the code did the opposite — `git push https://x-access-token:$TOKEN@...`
    puts the token straight into argv, where it is readable from the job
    container's process list for the duration of the push.
  * Because the URL carried the token, the whole command had to be silenced
    with `>/dev/null 2>&1` to keep it out of the log. That also threw away the
    reason a failed push failed. An auth error, a non-fast-forward, or a
    network blip would surface as a red step with no diagnostic at all — on a
    workflow that runs unattended a couple of times a week.

The token now goes into a 0600 credentials file in a mktemp directory that a
trap removes, supplied via `git -c credential.helper=store --file=…`. The
remote URL is plain, so stderr can flow normally and a failure explains itself.

Verified the mechanism rather than assuming it: `git ls-remote` against a
private repo fails with "could not read Username" when the helper is absent
and resolves HEAD when it is present.

Note for later, not changed here: `git clone https://x-access-token:${{
secrets.IAC_GITHUB_TOKEN }}@github.com/...` is the house pattern for the IaC
manifest bump and carries the same argv exposure. It appears in at least
bubbles, domidman, finchi, flatten, jiun-api, nolbul, oh-my-prompt and tokka,
so it wants one deliberate sweep rather than a drive-by edit here.