### PR TITLE
ci: bound every job with timeout-minutes

### DIFF
--- a/.gitea/workflows/release.yml
+++ b/.gitea/workflows/release.yml
@@ -45,6 +45,7 @@ concurrency:
 jobs:
   release:
     runs-on: ubuntu-latest
+    timeout-minutes: 25
     # Skip if commit message contains [skip ci] or [no release]
     if: |
       !contains(github.event.head_commit.message, '[skip ci]') &&


### PR DESCRIPTION
An AIR source release gate run hung for three hours today. It normally takes
4-7 minutes; it sat at 0.0% CPU inside browser-air-workbench.mjs and only
stopped because I killed the container. Nothing in the workflow bounded it.

On GitHub an unbounded hang costs money and nothing else, because runners are
effectively unlimited. On the self-hosted runner it costs availability: jiun-mini
runs at `capacity: 2` with `runner.timeout: 3h`, so one hung job takes half the
fleet's capacity for three hours and two would stop CI for every repository.
That is exactly what happened — the slot was gone until it was killed by hand.

Every job now carries a ceiling sized from measured durations with generous
headroom, so a hang fails in minutes instead of hours. None of these should ever
be reached in normal operation; they exist to convert a hang into a failure.

topdeck-mac already had timeout-minutes from its GitHub original and is
unchanged.