### PR TITLE
feat(scripts): manage personal CLI scripts via bin/ and symlinks

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ Components:
   codex         Codex CLI/App config, hooks, and notify chain
   claude        Claude Code settings, hooks, skill index, memory, MCP
   cship         cship + Starship (fast Claude Code statusline)
+  scripts       Personal CLI scripts linked into ~/.local/bin
 ```
 
 ## Components
@@ -369,7 +370,10 @@ settings/
 │   ├── hammerspoon.sh     #   Hammerspoon (macOS-only)
 │   ├── codex.sh           #   Codex CLI/App config
 │   ├── claude.sh          #   Claude Code settings, skills and memory
-│   └── cship.sh           #   cship + Starship statusline
+│   ├── cship.sh           #   cship + Starship statusline
+│   └── scripts.sh         #   Personal CLI scripts → ~/.local/bin
+├── bin/                    # Personal CLI scripts (linked onto PATH)
+│   └── subd               #   Run a command across subdirectories
 ├── worker/                 # Cloudflare Worker (settings.jiun.dev)
 │   ├── index.js           #   Proxy raw GitHub content
 │   └── wrangler.toml      #   Wrangler configuration

--- a/bin/convert_sample_rate.sh
+++ b/bin/convert_sample_rate.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+INPUT_PATH="$1"
+OUTPUT_PATH="$2"
+TARGET_SAMPLE_RATE="$3"
+
+if [ -d "$INPUT_PATH" ]; then
+    # 입력이 디렉토리일 경우: 출력도 디렉토리여야 함
+    mkdir -p "$OUTPUT_PATH"
+
+    for file in "$INPUT_PATH"/*.wav; do
+        [ -e "$file" ] || continue  # wav 파일이 없으면 건너뜀
+        filename=$(basename "$file" .wav)
+        ffmpeg -y -i "$file" -ar "$TARGET_SAMPLE_RATE" -ac 1 "$OUTPUT_PATH/${filename}.wav"
+    done
+
+elif [ -f "$INPUT_PATH" ]; then
+    # 입력이 단일 파일일 경우: 출력은 파일 경로
+    output_dir=$(dirname "$OUTPUT_PATH")
+    mkdir -p "$output_dir"
+
+    ffmpeg -y -i "$INPUT_PATH" -ar "$TARGET_SAMPLE_RATE" -ac 1 "$OUTPUT_PATH"
+
+else
+    echo "Error: 입력 경로가 존재하지 않습니다: $INPUT_PATH"
+    exit 1
+fi

--- a/bin/get_audio_duration.sh
+++ b/bin/get_audio_duration.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# usage: get_audio_duration.sh /path/to/dir
+
+DIR="$1"
+
+TOTAL=0
+for f in "$DIR"/*.wav; do
+  DUR=$(ffprobe -v error -show_entries format=duration \
+        -of default=noprint_wrappers=1:nokey=1 "$f")
+
+  DUR_FMT=$(awk -v d="$DUR" 'BEGIN{printf "%.3f", d}')
+  echo "$f,$DUR_FMT"
+  TOTAL=$(awk -v a="$TOTAL" -v b="$DUR_FMT" 'BEGIN{printf "%.3f", a+b}')
+done
+
+echo "TOTAL,$TOTAL"

--- a/bin/get_audio_duration.sh
+++ b/bin/get_audio_duration.sh
@@ -1,16 +1,54 @@
 #!/usr/bin/env bash
 # usage: get_audio_duration.sh /path/to/dir
+# Print "<file>,<seconds>" per .wav in a directory, then a TOTAL row.
+set -uo pipefail
 
-DIR="$1"
+DIR="${1-}"
+
+if [[ -z "$DIR" ]]; then
+    echo "Usage: $(basename "$0") <directory>" >&2
+    exit 2
+fi
+
+if [[ ! -d "$DIR" ]]; then
+    echo "Error: not a directory: $DIR" >&2
+    exit 2
+fi
+
+if ! command -v ffprobe > /dev/null 2>&1; then
+    echo "Error: ffprobe not found (install ffmpeg)" >&2
+    exit 2
+fi
 
 TOTAL=0
-for f in "$DIR"/*.wav; do
-  DUR=$(ffprobe -v error -show_entries format=duration \
-        -of default=noprint_wrappers=1:nokey=1 "$f")
+COUNT=0
+FAILED=0
 
-  DUR_FMT=$(awk -v d="$DUR" 'BEGIN{printf "%.3f", d}')
-  echo "$f,$DUR_FMT"
-  TOTAL=$(awk -v a="$TOTAL" -v b="$DUR_FMT" 'BEGIN{printf "%.3f", a+b}')
+# nullglob keeps an unmatched pattern from being emitted as a literal data row,
+# which downstream CSV consumers would ingest as a real file.
+shopt -s nullglob
+
+for f in "$DIR"/*.wav; do
+    if ! DUR=$(ffprobe -v error -show_entries format=duration \
+        -of default=noprint_wrappers=1:nokey=1 "$f"); then
+        echo "Error: could not read duration: $f" >&2
+        FAILED=$((FAILED + 1))
+        continue
+    fi
+
+    DUR_FMT=$(awk -v d="$DUR" 'BEGIN{printf "%.3f", d}')
+    echo "$f,$DUR_FMT"
+    TOTAL=$(awk -v a="$TOTAL" -v b="$DUR_FMT" 'BEGIN{printf "%.3f", a+b}')
+    COUNT=$((COUNT + 1))
 done
 
+shopt -u nullglob
+
+if (( COUNT == 0 && FAILED == 0 )); then
+    echo "No .wav files in $DIR" >&2
+    exit 3
+fi
+
 echo "TOTAL,$TOTAL"
+
+(( FAILED == 0 ))

--- a/bin/machine-info
+++ b/bin/machine-info
@@ -1,20 +1,99 @@
-#!/bin/bash
+#!/usr/bin/env bash
+# One-line host summary: CPU, RAM and GPU.
+set -uo pipefail
 
-cpu_name=$(lscpu | awk -F: '/Model name/ {print $2}' | sed 's/^[ \t]*//')
-physical_cpu_count=$(lscpu | awk '/^Socket\(s\):/ {print $2}')
-core_count=$(lscpu | awk '/^Core\(s\) per socket:/ {print $4}')
-threads_per_core=$(lscpu | awk '/^Thread\(s\) per core:/ {print $4}')
-memory_size_gib=$(free -k | awk '/Mem:/ {printf "%.2f", $2/1024/1024}')
-current_memory_usage_gib=$(free -k | awk '/Mem:/ {printf "%.2f", $3/1024/1024}')
-memory_usage_ratio=$(free -k | awk '/Mem:/ {printf "%.2f", $3/$2*100}')
+cpu_name="unknown"
+socket_count=""
+core_count=""
+thread_count=""
+memory_total_gib=""
+memory_used_gib=""
+memory_ratio=""
 
-gpu_names=""
-if command -v nvidia-smi &> /dev/null; then
-  gpu_names=$(nvidia-smi --query-gpu=name --format=csv,noheader | sort | uniq -c)
+read_linux() {
+    local lscpu_out
+    lscpu_out=$(lscpu 2>/dev/null) || return 1
+
+    cpu_name=$(awk -F: '/Model name/ {sub(/^[ \t]+/, "", $2); print $2; exit}' <<< "$lscpu_out")
+    socket_count=$(awk '/^Socket\(s\):/ {print $2; exit}' <<< "$lscpu_out")
+    local per_socket threads_per_core
+    per_socket=$(awk '/^Core\(s\) per socket:/ {print $4; exit}' <<< "$lscpu_out")
+    threads_per_core=$(awk '/^Thread\(s\) per core:/ {print $4; exit}' <<< "$lscpu_out")
+
+    if [[ $per_socket =~ ^[0-9]+$ && $socket_count =~ ^[0-9]+$ ]]; then
+        core_count=$(( per_socket * socket_count ))
+        [[ $threads_per_core =~ ^[0-9]+$ ]] && thread_count=$(( core_count * threads_per_core ))
+    fi
+
+    local mem
+    mem=$(free -k 2>/dev/null | awk '/Mem:/ {printf "%.2f %.2f %.2f", $3/1024/1024, $2/1024/1024, $3/$2*100; exit}')
+    [[ -n $mem ]] && read -r memory_used_gib memory_total_gib memory_ratio <<< "$mem"
+    return 0
+}
+
+read_macos() {
+    command -v sysctl > /dev/null 2>&1 || return 1
+
+    cpu_name=$(sysctl -n machdep.cpu.brand_string 2>/dev/null) || cpu_name="unknown"
+    socket_count=1
+    core_count=$(sysctl -n hw.physicalcpu 2>/dev/null)
+    thread_count=$(sysctl -n hw.logicalcpu 2>/dev/null)
+
+    local total_bytes
+    total_bytes=$(sysctl -n hw.memsize 2>/dev/null)
+    if [[ $total_bytes =~ ^[0-9]+$ ]]; then
+        memory_total_gib=$(awk -v b="$total_bytes" 'BEGIN{printf "%.2f", b/1024/1024/1024}')
+        # vm_stat reports pages; anything not free/inactive counts as in use.
+        local used
+        used=$(vm_stat 2>/dev/null | awk '
+            /page size of/ { match($0, /[0-9]+/); ps = substr($0, RSTART, RLENGTH) }
+            /Pages active/ { gsub(/\./, "", $3); a = $3 }
+            /Pages wired down/ { gsub(/\./, "", $4); w = $4 }
+            END { if (ps && (a || w)) printf "%.2f", (a + w) * ps / 1024 / 1024 / 1024 }')
+        if [[ -n $used ]]; then
+            memory_used_gib=$used
+            memory_ratio=$(awk -v u="$used" -v t="$memory_total_gib" 'BEGIN{ if (t > 0) printf "%.2f", u/t*100 }')
+        fi
+    fi
+    return 0
+}
+
+case "$(uname -s)" in
+    Darwin) read_macos || true ;;
+    *)      read_linux || read_macos || true ;;
+esac
+
+printf ' %s\n' "$(hostname)"
+
+cpu_line=" CPU:"
+[[ -n $socket_count ]] && cpu_line+=" ($socket_count)"
+if [[ -n $core_count && -n $thread_count ]]; then
+    cpu_line+=" (${core_count}C${thread_count}T)"
+elif [[ -n $core_count ]]; then
+    cpu_line+=" (${core_count}C)"
+fi
+printf '%s %s\n' "$cpu_line" "$cpu_name"
+
+if [[ -n $memory_used_gib && -n $memory_total_gib ]]; then
+    printf ' RAM: %s / %s GiB (%s%%)\n' "$memory_used_gib" "$memory_total_gib" "${memory_ratio:-?}"
+elif [[ -n $memory_total_gib ]]; then
+    printf ' RAM: %s GiB\n' "$memory_total_gib"
+else
+    printf ' RAM: unavailable\n'
 fi
 
-echo " $(hostname)"
-echo " CPU: ($physical_cpu_count) (${core_count}C$(($core_count * $threads_per_core))T) $cpu_name"
-echo " RAM: $current_memory_usage_gib / $memory_size_gib GiB ($memory_usage_ratio%)"
-echo "󱐋 GPU: $gpu_names" | awk '{printf $1 " " $2 " (" $3 ") "; for (i = 4; i <= NF; i++) printf "%s", $i (i == NF ? "" : " "); print ""}'
-
+# One line per distinct GPU model. The previous single-line awk reformatter
+# mangled every model after the first on heterogeneous hosts.
+if command -v nvidia-smi > /dev/null 2>&1; then
+    gpu_lines=$(nvidia-smi --query-gpu=name --format=csv,noheader 2>/dev/null | sort | uniq -c)
+    if [[ -n $gpu_lines ]]; then
+        while read -r count name; do
+            [[ -n $name ]] || continue
+            printf '󱐋 GPU: (%s) %s\n' "$count" "$name"
+        done <<< "$gpu_lines"
+    else
+        printf '󱐋 GPU: none detected\n'
+    fi
+else
+    printf '󱐋 GPU: none detected\n'
+fi

--- a/bin/machine-info
+++ b/bin/machine-info
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+cpu_name=$(lscpu | awk -F: '/Model name/ {print $2}' | sed 's/^[ \t]*//')
+physical_cpu_count=$(lscpu | awk '/^Socket\(s\):/ {print $2}')
+core_count=$(lscpu | awk '/^Core\(s\) per socket:/ {print $4}')
+threads_per_core=$(lscpu | awk '/^Thread\(s\) per core:/ {print $4}')
+memory_size_gib=$(free -k | awk '/Mem:/ {printf "%.2f", $2/1024/1024}')
+current_memory_usage_gib=$(free -k | awk '/Mem:/ {printf "%.2f", $3/1024/1024}')
+memory_usage_ratio=$(free -k | awk '/Mem:/ {printf "%.2f", $3/$2*100}')
+
+gpu_names=""
+if command -v nvidia-smi &> /dev/null; then
+  gpu_names=$(nvidia-smi --query-gpu=name --format=csv,noheader | sort | uniq -c)
+fi
+
+echo " $(hostname)"
+echo " CPU: ($physical_cpu_count) (${core_count}C$(($core_count * $threads_per_core))T) $cpu_name"
+echo " RAM: $current_memory_usage_gib / $memory_size_gib GiB ($memory_usage_ratio%)"
+echo "󱐋 GPU: $gpu_names" | awk '{printf $1 " " $2 " (" $3 ") "; for (i = 4; i <= NF; i++) printf "%s", $i (i == NF ? "" : " "); print ""}'
+

--- a/bin/mkln
+++ b/bin/mkln
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+source_dir="$1"
+target_dir="$2"
+absolute=false
+
+if [ "$3" == "--absolute" ]; then
+  absolute=true
+fi
+
+if [ -z "$source_dir" ] || [ -z "$target_dir" ]; then
+  echo "Usage: $0 /path/to/source/directory /path/to/target/directory [--absolute]"
+  exit 1
+fi
+
+mkdir -p "$target_dir"
+
+absolute_source_dir=$(realpath "$source_dir")
+absolute_target_dir=$(realpath "$target_dir")
+
+for file in "$source_dir"/*; do
+  filename=$(basename "$file")
+
+  if $absolute; then
+    link_target=$(realpath "$file")
+  else
+    relative_source=$(realpath --relative-to="$absolute_target_dir" "$file")
+    link_target="$relative_source"
+  fi
+
+  ln -s "$link_target" "$target_dir/$filename"
+done
+
+echo "Symbolic links created in $target_dir"
+

--- a/bin/mkln
+++ b/bin/mkln
@@ -1,35 +1,90 @@
-#!/bin/bash
+#!/usr/bin/env bash
+# Symlink every entry of a source directory into a target directory.
+set -uo pipefail
 
-source_dir="$1"
-target_dir="$2"
+usage() {
+    echo "Usage: $(basename "$0") <source-dir> <target-dir> [--absolute]" >&2
+}
+
+source_dir="${1-}"
+target_dir="${2-}"
+mode="${3-}"
 absolute=false
 
-if [ "$3" == "--absolute" ]; then
-  absolute=true
+if [[ -z "$source_dir" || -z "$target_dir" ]]; then
+    usage
+    exit 2
 fi
 
-if [ -z "$source_dir" ] || [ -z "$target_dir" ]; then
-  echo "Usage: $0 /path/to/source/directory /path/to/target/directory [--absolute]"
-  exit 1
+case "$mode" in
+    --absolute) absolute=true ;;
+    "")         ;;
+    *)          echo "Unknown option: $mode" >&2; usage; exit 2 ;;
+esac
+
+if [[ ! -d "$source_dir" ]]; then
+    echo "Error: not a directory: $source_dir" >&2
+    exit 2
 fi
+
+# `realpath --relative-to` is GNU coreutils only; macOS has no realpath at all
+# in the base system, and its BSD build lacks the flag. Compute the relative
+# path here so both platforms behave the same.
+relpath() {
+    local target=$1 base=$2 up=""
+    while [[ "$target/" != "$base"/* ]]; do
+        base=$(dirname "$base")
+        up="../$up"
+        [[ "$base" == "/" ]] && break
+    done
+    local rest=${target#"$base"}
+    rest=${rest#/}
+    printf '%s' "${up}${rest}"
+}
+
+abspath() {
+    local dir base
+    dir=$(dirname "$1")
+    base=$(basename "$1")
+    printf '%s/%s' "$(cd "$dir" && pwd -P)" "$base"
+}
 
 mkdir -p "$target_dir"
 
-absolute_source_dir=$(realpath "$source_dir")
-absolute_target_dir=$(realpath "$target_dir")
+absolute_target_dir=$(cd "$target_dir" && pwd -P)
+
+created=0
+failed=0
+shopt -s nullglob
 
 for file in "$source_dir"/*; do
-  filename=$(basename "$file")
+    filename=$(basename "$file")
+    absolute_file=$(abspath "$file")
 
-  if $absolute; then
-    link_target=$(realpath "$file")
-  else
-    relative_source=$(realpath --relative-to="$absolute_target_dir" "$file")
-    link_target="$relative_source"
-  fi
+    if $absolute; then
+        link_target=$absolute_file
+    else
+        link_target=$(relpath "$absolute_file" "$absolute_target_dir")
+    fi
 
-  ln -s "$link_target" "$target_dir/$filename"
+    if ln -s "$link_target" "$target_dir/$filename" 2>/dev/null; then
+        created=$((created + 1))
+    else
+        echo "Error: could not link $filename (already exists?)" >&2
+        failed=$((failed + 1))
+    fi
 done
 
-echo "Symbolic links created in $target_dir"
+shopt -u nullglob
 
+if (( created == 0 && failed == 0 )); then
+    echo "No entries in $source_dir; nothing to link."
+    exit 0
+fi
+
+echo "Created $created symbolic link(s) in $target_dir"
+
+if (( failed > 0 )); then
+    echo "$failed entry/entries could not be linked." >&2
+    exit 1
+fi

--- a/bin/mp4-to-wav.sh
+++ b/bin/mp4-to-wav.sh
@@ -71,3 +71,7 @@ while IFS= read -r -d '' f; do
 done < <(find "$ROOT" -type f -iname '*.mp4' -print0)
 
 echo "완료: 변환 ${converted}개, 건너뜀 ${skipped}개, 에러 ${errors}개"
+
+# 변환이 하나라도 실패하면 종료 코드로 알린다.
+# 그렇지 않으면 `mp4-to-wav.sh dir && start-training` 이 WAV 없이 진행된다.
+(( errors == 0 ))

--- a/bin/mp4-to-wav.sh
+++ b/bin/mp4-to-wav.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# mp4_to_wav16k.sh
+# 주어진 디렉토리에서 .mp4 파일을 찾아 16kHz mono WAV로 변환
+
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+사용법: mp4_to_wav16k.sh [-y] <디렉토리>
+  -y  기존 WAV가 있어도 덮어쓰기(ffmpeg -y). 기본은 덮어쓰지 않음(ffmpeg -n).
+예:   mp4_to_wav16k.sh /path/to/folder
+      mp4_to_wav16k.sh -y "./내 동영상들"
+USAGE
+}
+
+# 옵션 파싱
+OVERWRITE="-n"
+while getopts ":yh" opt; do
+  case "$opt" in
+    y) OVERWRITE="-y" ;;
+    h) usage; exit 0 ;;
+    \?) echo "알 수 없는 옵션: -$OPTARG" >&2; usage; exit 1 ;;
+  esac
+done
+shift $((OPTIND-1))
+
+# 인자 확인
+if [[ $# -ne 1 ]]; then
+  usage; exit 1
+fi
+
+ROOT="$1"
+
+# ffmpeg 존재 확인
+if ! command -v ffmpeg >/dev/null 2>&1; then
+  echo "에러: ffmpeg가 설치되어 있지 않습니다. 설치 후 다시 시도하세요." >&2
+  exit 1
+fi
+
+# 경로 확인
+if [[ ! -d "$ROOT" ]]; then
+  echo "에러: 디렉토리를 찾을 수 없습니다: $ROOT" >&2
+  exit 1
+fi
+
+# 변환 실행
+# - 하위 디렉토리 포함
+# - 널 종단으로 공백/특수문자 파일명 안전 처리
+# - 비디오 스트림은 제거(-vn), 16kHz(-ar 16000), 모노(-ac 1), 16-bit PCM(-acodec pcm_s16le)
+# - 출력은 입력과 같은 폴더에 같은 이름의 .wav로 생성
+converted=0
+skipped=0
+errors=0
+
+while IFS= read -r -d '' f; do
+  out="${f%.*}.wav"
+  if [[ "$OVERWRITE" == "-n" && -e "$out" ]]; then
+    echo "건너뜀(이미 존재): $out"
+    ((skipped++)) || true
+    continue
+  fi
+
+  echo "변환: $f -> $out"
+  if ffmpeg -hide_banner -loglevel error -nostdin $OVERWRITE \
+    -i "$f" -vn -ac 1 -ar 16000 -acodec pcm_s16le "$out"; then
+    ((converted++)) || true
+  else
+    echo "에러: 변환 실패 -> $f" >&2
+    ((errors++)) || true
+  fi
+done < <(find "$ROOT" -type f -iname '*.mp4' -print0)
+
+echo "완료: 변환 ${converted}개, 건너뜀 ${skipped}개, 에러 ${errors}개"

--- a/bin/pip-install.sh
+++ b/bin/pip-install.sh
@@ -1,18 +1,42 @@
 #!/bin/bash
+# Editable-install every package directory under a target directory.
+set -uo pipefail
 
-TARGET_DIR="$1"
+TARGET_DIR="${1-}"
 EXCLUDE_DIRS=("_" "datasets" "iac")
 
+if [[ -z "$TARGET_DIR" ]]; then
+    echo "Usage: $(basename "$0") <directory>" >&2
+    exit 2
+fi
+
+if [[ ! -d "$TARGET_DIR" ]]; then
+    echo "Error: not a directory: $TARGET_DIR" >&2
+    exit 2
+fi
+
+failed=0
+
 for SUB_DIR in "$TARGET_DIR"/*; do
-    if [ -d "$SUB_DIR" ]; then
-        BASENAME=$(basename "$SUB_DIR")
-        if [[ ! " ${EXCLUDE_DIRS[@]} " =~ " $BASENAME " ]]; then
-            echo "Installing $BASENAME..."
-            if pip install -e "$SUB_DIR" > /dev/null 2>&1; then
-                echo "> $BASENAME installed successfully."
-            else
-                echo "> Failed to install $BASENAME."
-            fi
-        fi
+    [[ -d "$SUB_DIR" ]] || continue
+
+    BASENAME=$(basename "$SUB_DIR")
+    # Literal membership test; =~ against a quoted RHS matches as a regex, so a
+    # directory name holding a metacharacter was excluded or kept wrongly.
+    if [[ " ${EXCLUDE_DIRS[*]} " == *" $BASENAME "* ]]; then
+        continue
+    fi
+
+    echo "Installing $BASENAME..."
+    if pip install -e "$SUB_DIR"; then
+        echo "> $BASENAME installed successfully."
+    else
+        echo "> Failed to install $BASENAME." >&2
+        failed=$((failed + 1))
     fi
 done
+
+if (( failed > 0 )); then
+    echo "$failed package(s) failed to install." >&2
+    exit 1
+fi

--- a/bin/pip-install.sh
+++ b/bin/pip-install.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+TARGET_DIR="$1"
+EXCLUDE_DIRS=("_" "datasets" "iac")
+
+for SUB_DIR in "$TARGET_DIR"/*; do
+    if [ -d "$SUB_DIR" ]; then
+        BASENAME=$(basename "$SUB_DIR")
+        if [[ ! " ${EXCLUDE_DIRS[@]} " =~ " $BASENAME " ]]; then
+            echo "Installing $BASENAME..."
+            if pip install -e "$SUB_DIR" > /dev/null 2>&1; then
+                echo "> $BASENAME installed successfully."
+            else
+                echo "> Failed to install $BASENAME."
+            fi
+        fi
+    fi
+done

--- a/bin/subd
+++ b/bin/subd
@@ -400,7 +400,13 @@ exec_node() {
     if $INTERACTIVE && ! $RAW; then
         out=$(printf '%s\n' "$out" | filter_noise | squeeze_blanks)
     fi
-    out=$(printf '%s\n' "$out" | trim_blank_edges)
+    # $(...) 가 이미 뒤쪽 개행을 걷어내므로 대개 트림할 것이 없다.
+    # 그 경우 디렉토리마다 awk 를 fork 하지 않고 넘어간다.
+    if [[ -n $out && $out != [[:space:]]* && $out != *[[:space:]] ]]; then
+        :
+    else
+        out=$(printf '%s\n' "$out" | trim_blank_edges)
+    fi
 
     printf '%s' "$out" > "$WORK/$i.out"
     printf '%s' "$rc"  > "$WORK/$i.rc"

--- a/bin/subd
+++ b/bin/subd
@@ -42,7 +42,7 @@ declare -ra DEFAULT_EXCLUDES=(
 # -i (interactive) 모드에서만 적용되는 프롬프트 플러그인 노이즈 패턴.
 # 앵커를 걸어 사용자 출력(예: "[2026-08-24 ERROR] db failed")을 삼키지 않게 한다.
 # 매칭은 ANSI 이스케이프를 제거한 사본에 대해 수행한다 (p10k 가 노이즈를 색칠해서 보냄).
-readonly NOISE_RE='^[(]eval[)]:[0-9]+: can'"'"'t change option: |^[(]anon[)]:setopt:[0-9]+: can'"'"'t change option: |gitstatus|^[[:space:]]*Add the following parameter to |^[[:space:]]*GITSTATUS_LOG_LEVEL=DEBUG[[:space:]]*$|^[[:space:]]*Restart Zsh to retry |^[[:space:]]*exec zsh[[:space:]]*$'
+readonly NOISE_RE='^[(]eval[)]:[0-9]+: can'"'"'t change option: |^[(]anon[)]:setopt:[0-9]+: can'"'"'t change option: |^[[]ERROR[]]: gitstatus |^[[:space:]]*Add the following parameter to |^[[:space:]]*GITSTATUS_LOG_LEVEL=DEBUG[[:space:]]*$|^[[:space:]]*Restart Zsh to retry |^[[:space:]]*exec zsh[[:space:]]*$'
 
 # `wait -n` 은 bash 4.3+ 에서만 쓸 수 있다. 없으면 배치 단위로 대기한다.
 if (( BASH_VERSINFO[0] > 4 || ( BASH_VERSINFO[0] == 4 && BASH_VERSINFO[1] >= 3 ) )); then
@@ -140,7 +140,7 @@ Usage:
   -V, --version        버전
 
 종료 코드:
-  0 전부 성공 / 1 하나 이상 실패 / 2 사용법 오류 / 130 중단
+  0 전부 성공 / 1 하나 이상 실패 / 2 사용법 오류 / 3 대상 없음 / 130 중단
 
 명령에 주입되는 환경변수:
   SUBD_DIR   현재 디렉토리 절대경로
@@ -349,7 +349,7 @@ run_in_dir() {
             # 셸을 거치지 않는 직접 exec — 가장 빠르고 인용이 완전히 보존된다.
             exec ${pre[@]+"${pre[@]}"} "${COMMAND[@]}"
         fi
-    ) 2>&1
+    ) < /dev/null 2>&1
 }
 
 # -i 모드 노이즈 제거. ANSI 를 지운 사본으로 매칭하고, 출력은 원본 그대로 유지한다.
@@ -520,7 +520,7 @@ summarize() {
 
     if (( total == 0 )); then
         printf 'subd: no matching directories\n' >&2
-        return 0
+        return 3
     fi
     if $DRY_RUN; then
         printf 'subd: %d dir(s) would run (dry-run)\n' "$total" >&2

--- a/bin/subd
+++ b/bin/subd
@@ -44,6 +44,13 @@ declare -ra DEFAULT_EXCLUDES=(
 # 매칭은 ANSI 이스케이프를 제거한 사본에 대해 수행한다 (p10k 가 노이즈를 색칠해서 보냄).
 readonly NOISE_RE='^[(]eval[)]:[0-9]+: can'"'"'t change option: |^[(]anon[)]:setopt:[0-9]+: can'"'"'t change option: |gitstatus|^[[:space:]]*Add the following parameter to |^[[:space:]]*GITSTATUS_LOG_LEVEL=DEBUG[[:space:]]*$|^[[:space:]]*Restart Zsh to retry |^[[:space:]]*exec zsh[[:space:]]*$'
 
+# `wait -n` 은 bash 4.3+ 에서만 쓸 수 있다. 없으면 배치 단위로 대기한다.
+if (( BASH_VERSINFO[0] > 4 || ( BASH_VERSINFO[0] == 4 && BASH_VERSINFO[1] >= 3 ) )); then
+    HAVE_WAIT_N=true
+else
+    HAVE_WAIT_N=false
+fi
+
 C_DIR=""; C_ERR=""; C_DIM=""; C_RST=""
 WORK=""
 PRE_EXECUTED=false
@@ -234,7 +241,7 @@ validate_options() {
 # ==============================================================================
 is_excluded() {
     local path=$1 base=${1##*/} pat
-    for pat in "${EXCLUDES[@]}"; do
+    for pat in ${EXCLUDES[@]+"${EXCLUDES[@]}"}; do
         # shellcheck disable=SC2053  # glob 매칭이 의도한 동작
         [[ $base == $pat ]] && return 0
         # shellcheck disable=SC2053
@@ -268,7 +275,7 @@ collect() {
     done < <(find "$parent" "${find_opts[@]}" -print0 2>/dev/null | sort -z)  # 로케일 collation: ls/tree 와 같은 순서
 
     local idx ex
-    for child in "${kids[@]}"; do
+    for child in ${kids[@]+"${kids[@]}"}; do
         idx=$NODE_N; NODE_N=$((NODE_N + 1))
         NODE_PATH[idx]=$child
         NODE_KIDS[idx]=""
@@ -335,12 +342,12 @@ run_in_dir() {
             local cmd_str
             if $SHELL_MODE_SET; then cmd_str=$SHELL_MODE
             else cmd_str=$(quote_argv "${COMMAND[@]}"); fi
-            exec "${pre[@]}" "${SHELL:-/bin/bash}" -i -c "$cmd_str"
+            exec ${pre[@]+"${pre[@]}"} "${SHELL:-/bin/bash}" -i -c "$cmd_str"
         elif $SHELL_MODE_SET; then
-            exec "${pre[@]}" "${SHELL:-/bin/bash}" -c "$SHELL_MODE"
+            exec ${pre[@]+"${pre[@]}"} "${SHELL:-/bin/bash}" -c "$SHELL_MODE"
         else
             # 셸을 거치지 않는 직접 exec — 가장 빠르고 인용이 완전히 보존된다.
-            exec "${pre[@]}" "${COMMAND[@]}"
+            exec ${pre[@]+"${pre[@]}"} "${COMMAND[@]}"
         fi
     ) 2>&1
 }
@@ -411,11 +418,18 @@ run_parallel() {
     (( ${#targets[@]} == 0 )) && return 0
 
     local running=0
-    for i in "${targets[@]}"; do
-        while (( running >= JOBS )); do
-            wait -n 2>/dev/null
-            running=$((running - 1))
-        done
+    for i in ${targets[@]+"${targets[@]}"}; do
+        if $HAVE_WAIT_N; then
+            # 한 슬롯이 비는 대로 다음 작업을 넣는다 (bash 4.3+)
+            while (( running >= JOBS )); do
+                wait -n 2>/dev/null
+                running=$((running - 1))
+            done
+        elif (( running >= JOBS )); then
+            # 구버전 bash: 슬롯 단위로 기다릴 수 없어 한 배치를 통째로 비운다
+            wait
+            running=0
+        fi
         exec_node "$i" &
         running=$((running + 1))
     done
@@ -461,13 +475,13 @@ render() {
     kids=( ${NODE_KIDS[idx]} )
 
     local c
-    for c in "${kids[@]}"; do
+    for c in ${kids[@]+"${kids[@]}"}; do
         is_visible "$c" || continue
         shown+=("$c")
     done
 
     local n=${#shown[@]} i=0 last conn cpfx npfx
-    for c in "${shown[@]}"; do
+    for c in ${shown[@]+"${shown[@]}"}; do
         i=$((i + 1))
         last=0; (( i == n )) && last=1
 

--- a/bin/subd
+++ b/bin/subd
@@ -1,0 +1,553 @@
+#!/usr/bin/env bash
+# subd - Subdirectory Command Runner
+# 서브디렉토리를 순회하며 명령을 실행하고 tree 형태로 결과 출력
+#
+# v2 설계 원칙
+#   - 기본은 non-interactive: 셸을 거치지 않고 argv 를 그대로 exec (빠르고 인용 안전)
+#   - 출력은 절대 조용히 버리지 않는다 (필터는 -i 모드에서만, --raw 로 해제)
+#   - 하위 명령의 실패는 subd 의 종료 코드로 전파된다
+
+set -uo pipefail
+
+readonly SUBD_VERSION=2.0.0
+
+# ==============================================================================
+# 기본값
+# ==============================================================================
+DEPTH=1
+CONTINUOUS=false
+SHOW_HIDDEN=false
+ONLY_GIT=false
+PRUNE=false
+INTERACTIVE=false
+RAW=false
+DRY_RUN=false
+VERBOSE=false
+JOBS=1
+TIMEOUT=0
+COLOR_MODE=auto
+SHELL_MODE=""
+SHELL_MODE_SET=false
+USE_DEFAULT_EXCLUDES=true
+
+declare -a COMMAND=()
+declare -a EXCLUDES=()
+
+# 숨김 디렉토리는 기본적으로 제외되므로, 아래 목록은 주로 -a 와 함께 의미가 있다.
+declare -ra DEFAULT_EXCLUDES=(
+    node_modules venv .venv __pycache__ .mypy_cache .pytest_cache .ruff_cache
+    dist build target .next .nuxt .turbo vendor .terraform .gradle
+)
+
+# -i (interactive) 모드에서만 적용되는 프롬프트 플러그인 노이즈 패턴.
+# 앵커를 걸어 사용자 출력(예: "[2026-08-24 ERROR] db failed")을 삼키지 않게 한다.
+# 매칭은 ANSI 이스케이프를 제거한 사본에 대해 수행한다 (p10k 가 노이즈를 색칠해서 보냄).
+readonly NOISE_RE='^[(]eval[)]:[0-9]+: can'"'"'t change option: |^[(]anon[)]:setopt:[0-9]+: can'"'"'t change option: |gitstatus|^[[:space:]]*Add the following parameter to |^[[:space:]]*GITSTATUS_LOG_LEVEL=DEBUG[[:space:]]*$|^[[:space:]]*Restart Zsh to retry |^[[:space:]]*exec zsh[[:space:]]*$'
+
+C_DIR=""; C_ERR=""; C_DIM=""; C_RST=""
+WORK=""
+PRE_EXECUTED=false
+NODE_N=0
+declare -a NODE_PATH=() NODE_KIDS=() NODE_EXEC=() NODE_KEEP=()
+
+# ==============================================================================
+# 유틸
+# ==============================================================================
+die() { printf 'subd: %s\n' "$1" >&2; exit "${2:-2}"; }
+is_pint() { [[ ${1-} =~ ^[1-9][0-9]*$ ]]; }
+
+need_val() {
+    # $1=플래그 이름, $2=값(없을 수 있음)
+    [[ ${2-} != "" && ${2-} != -* ]] || die "$1 requires a value"
+}
+
+default_jobs() {
+    local n
+    n=$( { nproc 2>/dev/null || getconf _NPROCESSORS_ONLN 2>/dev/null; } | head -1 )
+    is_pint "${n:-}" || n=2
+    # git 작업은 대개 I/O·네트워크 바운드라 코어 수보다 높게 잡는다.
+    n=$(( n * 4 ))
+    (( n < 4 )) && n=4
+    (( n > 16 )) && n=16
+    printf '%s' "$n"
+}
+
+setup_color() {
+    local on=false
+    case $COLOR_MODE in
+        always) on=true ;;
+        never)  on=false ;;
+        auto)   [[ -t 1 && -z ${NO_COLOR-} ]] && on=true ;;
+        *)      die "--color must be one of: auto, always, never" ;;
+    esac
+    if $on; then
+        C_DIR=$'\033[1;34m'; C_ERR=$'\033[0;31m'; C_DIM=$'\033[2m'; C_RST=$'\033[0m'
+    fi
+}
+
+cleanup() {
+    [[ -n $WORK && -d $WORK ]] && rm -rf -- "$WORK"
+    return 0
+}
+
+on_interrupt() {
+    local pids
+    pids=$(jobs -p 2>/dev/null)
+    # shellcheck disable=SC2086  # 여러 PID 를 개별 인자로 넘기기 위한 의도적 분리
+    [[ -n $pids ]] && kill $pids 2>/dev/null
+    cleanup
+    exit 130
+}
+
+show_help() {
+    cat << 'EOF'
+subd - Subdirectory Command Runner
+
+Usage:
+  subd [OPTIONS] -- COMMAND [ARGS...]
+  subd [OPTIONS] -s 'SHELL COMMAND'
+
+순회 옵션:
+  -d, --depth N        순회 깊이 (기본값: 1)
+  -c, --continuous     1부터 depth 까지 모든 레벨에서 명령 실행
+  -a, --hidden         숨김 디렉토리 포함
+      --only-git       .git 이 있는 디렉토리에서만 실행 (--prune 자동 적용)
+  -x, --exclude PAT    디렉토리 제외 (basename 또는 경로 glob, 반복 지정 가능)
+      --no-default-exclude
+                       기본 제외 목록(node_modules, dist, target ...) 비활성화
+      --prune          실행 대상이 없는 가지는 트리에서 숨김
+
+실행 옵션:
+  -j, --jobs N         병렬 실행 (동시 N개)
+      --parallel [N]   -j 와 동일. N 생략 시 자동 결정 (코어수x4, 4~16)
+      --timeout N      디렉토리별 제한 시간 (초)
+  -s, --shell 'CMD'    파이프/&&/리다이렉션 등 셸 문법이 필요할 때 사용
+  -i, --interactive    셸 alias/function 이 필요할 때만 사용 (느림)
+      --raw            -i 모드의 프롬프트 노이즈 필터를 끔
+      --dry-run        실행 없이 대상 디렉토리만 표시
+
+출력 옵션:
+      --color WHEN     auto(기본) | always | never
+  -v, --verbose        출력 없는 성공도 표시하고 마지막에 요약 출력
+  -h, --help           도움말
+  -V, --version        버전
+
+종료 코드:
+  0 전부 성공 / 1 하나 이상 실패 / 2 사용법 오류 / 130 중단
+
+명령에 주입되는 환경변수:
+  SUBD_DIR   현재 디렉토리 절대경로
+  SUBD_NAME  현재 디렉토리 이름 (basename)
+  SUBD_REL   시작 지점 기준 상대경로
+
+Examples:
+  subd -- git status                    # depth 1 에서 git status
+  subd --only-git --parallel -- git status --short
+  subd --only-git -j 8 -- git pull      # 26개 repo 병렬 pull
+  subd --only-git -s 'git pull && git gone'   # 디렉토리마다 두 명령 모두 실행
+  subd -d 2 --prune -- npm test         # depth 2 에서만, 빈 가지 숨김
+  subd --dry-run --only-git -- git push # 대상 확인 후 실행
+  subd -- printf '[%s]\n' 'hello world' # 인용이 그대로 보존됨
+
+주의: `subd -- git pull && git gone` 의 && 는 subd 가 아니라 바깥 셸이 해석합니다.
+      디렉토리마다 두 명령을 모두 실행하려면 -s 를 쓰세요.
+EOF
+}
+
+# ==============================================================================
+# 옵션 파싱
+# ==============================================================================
+parse_options() {
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            -d|--depth)
+                need_val "$1" "${2-}"
+                is_pint "$2" || die "--depth must be a positive integer (got '$2')"
+                DEPTH=$2; shift 2 ;;
+            -c|--continuous) CONTINUOUS=true; shift ;;
+            -a|--hidden)     SHOW_HIDDEN=true; shift ;;
+            --only-git)      ONLY_GIT=true; PRUNE=true; shift ;;
+            --prune)         PRUNE=true; shift ;;
+            -x|--exclude)
+                need_val "$1" "${2-}"
+                EXCLUDES+=("$2"); shift 2 ;;
+            --no-default-exclude) USE_DEFAULT_EXCLUDES=false; shift ;;
+            -j|--jobs)
+                need_val "$1" "${2-}"
+                is_pint "$2" || die "$1 must be a positive integer (got '$2')"
+                JOBS=$2; shift 2 ;;
+            --parallel)
+                if is_pint "${2-}"; then JOBS=$2; shift 2
+                else JOBS=$(default_jobs); shift; fi ;;
+            --timeout)
+                need_val "$1" "${2-}"
+                is_pint "$2" || die "--timeout must be a positive integer (got '$2')"
+                TIMEOUT=$2; shift 2 ;;
+            -s|--shell)
+                need_val "$1" "${2-}"
+                SHELL_MODE=$2; SHELL_MODE_SET=true; shift 2 ;;
+            -i|--interactive) INTERACTIVE=true; shift ;;
+            --raw)            RAW=true; shift ;;
+            --dry-run)        DRY_RUN=true; shift ;;
+            -v|--verbose)     VERBOSE=true; shift ;;
+            --color)
+                need_val "$1" "${2-}"
+                COLOR_MODE=$2; shift 2 ;;
+            --color=*)        COLOR_MODE=${1#*=}; shift ;;
+            -h|--help)        show_help; exit 0 ;;
+            -V|--version)     printf 'subd %s\n' "$SUBD_VERSION"; exit 0 ;;
+            --)
+                shift; COMMAND=("$@"); return 0 ;;
+            -*)
+                printf 'subd: unknown option %s\n' "$1" >&2
+                printf "Use 'subd --help' for usage information\n" >&2
+                exit 2 ;;
+            *)
+                printf 'subd: use -- to separate options from the command\n' >&2
+                printf '  subd -d 2 -- git status\n' >&2
+                printf "  subd -s 'git pull && git gone'\n" >&2
+                exit 2 ;;
+        esac
+    done
+    return 0
+}
+
+validate_options() {
+    if $SHELL_MODE_SET && (( ${#COMMAND[@]} > 0 )); then
+        die "-s/--shell and '-- COMMAND' are mutually exclusive"
+    fi
+    if ! $SHELL_MODE_SET && (( ${#COMMAND[@]} == 0 )); then
+        printf 'subd: no command specified\n' >&2
+        printf '  subd -- git status\n' >&2
+        exit 2
+    fi
+    if $RAW && ! $INTERACTIVE; then
+        printf 'subd: --raw has no effect without -i (no filtering is applied by default)\n' >&2
+    fi
+    if (( TIMEOUT > 0 )) && ! command -v timeout > /dev/null 2>&1; then
+        die "--timeout requires the 'timeout' command (coreutils)"
+    fi
+}
+
+# ==============================================================================
+# 디렉토리 수집
+# ==============================================================================
+is_excluded() {
+    local path=$1 base=${1##*/} pat
+    for pat in "${EXCLUDES[@]}"; do
+        # shellcheck disable=SC2053  # glob 매칭이 의도한 동작
+        [[ $base == $pat ]] && return 0
+        # shellcheck disable=SC2053
+        [[ $path == $pat ]] && return 0
+    done
+    return 1
+}
+
+should_execute_at() {
+    local depth=$1
+    if $CONTINUOUS; then
+        (( depth >= 1 && depth <= DEPTH ))
+    else
+        (( depth == DEPTH ))
+    fi
+}
+
+collect() {
+    # $1=부모 경로, $2=부모 인덱스, $3=자식 깊이
+    local parent=$1 pidx=$2 depth=$3
+    (( depth > DEPTH )) && return 0
+
+    local -a find_opts=(-mindepth 1 -maxdepth 1 -type d)
+    $SHOW_HIDDEN || find_opts+=(-not -name '.*')
+
+    local -a kids=()
+    local child
+    while IFS= read -r -d '' child; do
+        is_excluded "$child" && continue
+        kids+=("$child")
+    done < <(find "$parent" "${find_opts[@]}" -print0 2>/dev/null | sort -z)  # 로케일 collation: ls/tree 와 같은 순서
+
+    local idx ex
+    for child in "${kids[@]}"; do
+        idx=$NODE_N; NODE_N=$((NODE_N + 1))
+        NODE_PATH[idx]=$child
+        NODE_KIDS[idx]=""
+        NODE_KIDS[pidx]+=" $idx"
+
+        ex=0
+        if should_execute_at "$depth"; then ex=1; fi
+        if (( ex )) && $ONLY_GIT && [[ ! -e $child/.git ]]; then ex=0; fi
+        NODE_EXEC[idx]=$ex
+
+        collect "$child" "$idx" $((depth + 1))
+    done
+    return 0
+}
+
+# 실행 대상이 자기 자신 또는 후손에 있는 노드만 keep
+compute_keep() {
+    local i c k
+    for (( i = NODE_N - 1; i >= 0; i-- )); do
+        k=${NODE_EXEC[i]}
+        if (( ! k )); then
+            for c in ${NODE_KIDS[i]}; do
+                if (( NODE_KEEP[c] )); then k=1; break; fi
+            done
+        fi
+        NODE_KEEP[i]=$k
+    done
+}
+
+is_visible() {
+    local i=$1
+    $PRUNE || return 0
+    (( NODE_KEEP[i] ))
+}
+
+# ==============================================================================
+# 실행
+# ==============================================================================
+quote_argv() {
+    local out='' a
+    for a in "$@"; do
+        out+="$(printf '%q' "$a") "
+    done
+    printf '%s' "$out"
+}
+
+run_in_dir() {
+    # $1=디렉토리. stdout 에 (stdout+stderr) 병합 출력, 반환값은 명령의 종료 코드.
+    local dir=$1
+    local -a pre=()
+    (( TIMEOUT > 0 )) && pre=(timeout --foreground "${TIMEOUT}s")
+
+    (
+        cd -- "$dir" || exit 126
+        SUBD_DIR=$PWD
+        SUBD_NAME=${dir##*/}
+        SUBD_REL=${dir#./}
+        export SUBD_DIR SUBD_NAME SUBD_REL
+
+        if $INTERACTIVE; then
+            # alias/function 해석을 위해 셸 재파싱이 필요하다.
+            # %q 로 인용하므로 재파싱이 무손실이고, 단순 단어는 인용되지 않아
+            # 첫 단어의 alias 확장이 그대로 동작한다.
+            local cmd_str
+            if $SHELL_MODE_SET; then cmd_str=$SHELL_MODE
+            else cmd_str=$(quote_argv "${COMMAND[@]}"); fi
+            exec "${pre[@]}" "${SHELL:-/bin/bash}" -i -c "$cmd_str"
+        elif $SHELL_MODE_SET; then
+            exec "${pre[@]}" "${SHELL:-/bin/bash}" -c "$SHELL_MODE"
+        else
+            # 셸을 거치지 않는 직접 exec — 가장 빠르고 인용이 완전히 보존된다.
+            exec "${pre[@]}" "${COMMAND[@]}"
+        fi
+    ) 2>&1
+}
+
+# -i 모드 노이즈 제거. ANSI 를 지운 사본으로 매칭하고, 출력은 원본 그대로 유지한다.
+filter_noise() {
+    awk -v re="$NOISE_RE" '
+        {
+            clean = $0
+            gsub(/\033\[[0-9;]*[A-Za-z]/, "", clean)
+            if (clean ~ re) next
+            print
+        }
+    '
+}
+
+# 노이즈 제거 후 남는 연속 빈 줄을 한 줄로 압축 (-i 모드에서만 사용)
+squeeze_blanks() {
+    awk '
+        /^[[:space:]]*$/ { pending = 1; next }
+        { if (pending && seen) print ""; pending = 0; seen = 1; print }
+    '
+}
+
+# 앞뒤 빈 줄만 제거하고 내부 빈 줄은 보존 (git log/diff 포매팅 유지)
+trim_blank_edges() {
+    awk '
+        { L[n++] = $0 }
+        END {
+            s = 0; e = n - 1
+            while (s < n  && L[s] ~ /^[[:space:]]*$/) s++
+            while (e >= s && L[e] ~ /^[[:space:]]*$/) e--
+            for (i = s; i <= e; i++) print L[i]
+        }
+    '
+}
+
+exec_node() {
+    local i=$1 out rc
+
+    if $DRY_RUN; then
+        : > "$WORK/$i.out"
+        printf '0' > "$WORK/$i.rc"
+        return 0
+    fi
+
+    out=$(run_in_dir "${NODE_PATH[i]}")
+    rc=$?
+
+    if $INTERACTIVE && ! $RAW; then
+        out=$(printf '%s\n' "$out" | filter_noise | squeeze_blanks)
+    fi
+    out=$(printf '%s\n' "$out" | trim_blank_edges)
+
+    printf '%s' "$out" > "$WORK/$i.out"
+    printf '%s' "$rc"  > "$WORK/$i.rc"
+    return 0
+}
+
+run_parallel() {
+    local -a targets=()
+    local i
+    for (( i = 1; i < NODE_N; i++ )); do
+        (( NODE_EXEC[i] )) || continue
+        is_visible "$i" || continue
+        targets+=("$i")
+    done
+    (( ${#targets[@]} == 0 )) && return 0
+
+    local running=0
+    for i in "${targets[@]}"; do
+        while (( running >= JOBS )); do
+            wait -n 2>/dev/null
+            running=$((running - 1))
+        done
+        exec_node "$i" &
+        running=$((running + 1))
+    done
+    wait
+    return 0
+}
+
+# ==============================================================================
+# 출력
+# ==============================================================================
+emit_output() {
+    local i=$1 pfx=$2 out rc line
+
+    if $DRY_RUN; then
+        printf '%s%s(dry-run)%s\n' "$pfx" "$C_DIM" "$C_RST"
+        return 0
+    fi
+
+    out=$(<"$WORK/$i.out")
+    rc=$(<"$WORK/$i.rc")
+
+    if [[ -n $out ]]; then
+        while IFS= read -r line || [[ -n $line ]]; do
+            if (( rc != 0 )); then
+                printf '%s%s%s%s\n' "$pfx" "$C_ERR" "$line" "$C_RST"
+            else
+                printf '%s%s\n' "$pfx" "$line"
+            fi
+        done <<< "$out"
+    elif (( rc != 0 )); then
+        printf '%s%s(exit %s, no output)%s\n' "$pfx" "$C_ERR" "$rc" "$C_RST"
+    elif $VERBOSE; then
+        printf '%s%s(ok, no output)%s\n' "$pfx" "$C_DIM" "$C_RST"
+    fi
+    return 0
+}
+
+render() {
+    # $1=노드 인덱스, $2=프리픽스
+    local idx=$1 pfx=$2
+    local -a kids=() shown=()
+    # shellcheck disable=SC2206  # 인덱스는 정수라 word splitting 이 의도된 동작
+    kids=( ${NODE_KIDS[idx]} )
+
+    local c
+    for c in "${kids[@]}"; do
+        is_visible "$c" || continue
+        shown+=("$c")
+    done
+
+    local n=${#shown[@]} i=0 last conn cpfx npfx
+    for c in "${shown[@]}"; do
+        i=$((i + 1))
+        last=0; (( i == n )) && last=1
+
+        if (( last )); then
+            conn='└── '; cpfx="$pfx    "; npfx="$pfx    "
+        else
+            conn='├── '; cpfx="$pfx│   "; npfx="$pfx│   "
+        fi
+
+        printf '%s%s%s%s/%s\n' "$pfx" "$conn" "$C_DIR" "${NODE_PATH[c]##*/}" "$C_RST"
+
+        if (( NODE_EXEC[c] )); then
+            $PRE_EXECUTED || exec_node "$c"
+            emit_output "$c" "$cpfx"
+        fi
+
+        render "$c" "$npfx"
+
+        if (( ! last )) && (( NODE_EXEC[c] )); then
+            printf '%s│\n' "$pfx"
+        fi
+    done
+    return 0
+}
+
+summarize() {
+    local i rc total=0 failed=0
+    for (( i = 1; i < NODE_N; i++ )); do
+        (( NODE_EXEC[i] )) || continue
+        is_visible "$i" || continue
+        [[ -f $WORK/$i.rc ]] || continue
+        total=$((total + 1))
+        rc=$(<"$WORK/$i.rc")
+        (( rc != 0 )) && failed=$((failed + 1))
+    done
+
+    if (( total == 0 )); then
+        printf 'subd: no matching directories\n' >&2
+        return 0
+    fi
+    if $DRY_RUN; then
+        printf 'subd: %d dir(s) would run (dry-run)\n' "$total" >&2
+        return 0
+    fi
+    if (( failed > 0 )) || $VERBOSE; then
+        printf 'subd: %d dir(s) run, %d failed\n' "$total" "$failed" >&2
+    fi
+    (( failed == 0 ))
+}
+
+# ==============================================================================
+# 메인
+# ==============================================================================
+main() {
+    parse_options "$@"
+    validate_options
+    setup_color
+
+    if $USE_DEFAULT_EXCLUDES; then
+        EXCLUDES+=("${DEFAULT_EXCLUDES[@]}")
+    fi
+
+    trap cleanup EXIT
+    trap on_interrupt INT TERM
+    WORK=$(mktemp -d "${TMPDIR:-/tmp}/subd.XXXXXXXX") || die "cannot create temp dir" 1
+
+    NODE_PATH[0]="."; NODE_KIDS[0]=""; NODE_EXEC[0]=0
+    NODE_N=1
+    collect "." 0 1
+    compute_keep
+
+    if (( JOBS > 1 )); then
+        run_parallel
+        PRE_EXECUTED=true
+    fi
+
+    printf '.\n'
+    render 0 ""
+
+    summarize
+}
+
+main "$@"

--- a/install.sh
+++ b/install.sh
@@ -43,6 +43,7 @@ source "$SCRIPT_DIR/modules/ghostty.sh"
 source "$SCRIPT_DIR/modules/codex.sh"
 source "$SCRIPT_DIR/modules/claude.sh"
 source "$SCRIPT_DIR/modules/cship.sh"
+source "$SCRIPT_DIR/modules/scripts.sh"
 
 # ==============================================================================
 # Component Names (for display) - bash 3.2 compatible
@@ -65,6 +66,7 @@ get_component_name() {
         codex)       echo "Codex CLI/App configuration" ;;
         claude)      echo "Claude Code configuration" ;;
         cship)       echo "cship (Claude Code statusline)" ;;
+        scripts)     echo "Personal CLI scripts" ;;
         *)           echo "$1" ;;
     esac
 }
@@ -157,6 +159,9 @@ main() {
                 ;;
             cship)
                 install_cship
+                ;;
+            scripts)
+                install_scripts
                 ;;
             *)
                 progress_info "Unknown component: $component"

--- a/lib/cli.sh
+++ b/lib/cli.sh
@@ -11,7 +11,7 @@ readonly VERSION="2.0.0"
 # Available Components
 # ==============================================================================
 # Component list (bash 3.2 compatible - no associative arrays)
-readonly COMPONENTS_ORDER=(base zsh nvim tmux zellij rust uv tools tools-extra ssh hishtory hammerspoon ghostty codex claude cship)
+readonly COMPONENTS_ORDER=(base zsh nvim tmux zellij rust uv tools tools-extra ssh hishtory hammerspoon ghostty codex claude cship scripts)
 
 # Basic components for --basic option
 readonly BASIC_COMPONENTS=(base zsh nvim tmux)
@@ -38,6 +38,7 @@ get_component_desc() {
         codex)       echo "Codex CLI/App config, hooks, and notify chain" ;;
         claude)      echo "Claude Code settings, hooks, skill index, memory, MCP servers" ;;
         cship)       echo "cship + Starship (fast Claude Code statusline, replaces ccstatusline)" ;;
+        scripts)     echo "Personal CLI scripts linked into ~/.local/bin" ;;
         *)           echo "" ;;
     esac
 }

--- a/modules/scripts.sh
+++ b/modules/scripts.sh
@@ -33,8 +33,8 @@ install_scripts() {
     local source_dir="$root_dir/bin"
 
     if [[ ! -d "$source_dir" ]]; then
-        log_error "Scripts directory not found at: $source_dir"
-        return 1
+        log_warn "bin directory not found in settings"
+        return 0
     fi
 
     print_section "Linking personal scripts"
@@ -78,8 +78,18 @@ install_scripts() {
 
         target="$SCRIPTS_BIN_DIR/$name"
 
-        # Short-circuit if it already points at our repo source
-        if [[ -L "$target" ]]; then
+        # Short-circuit when the target is already what we would install.
+        # Copy mode has to compare content: without this every re-run backs up
+        # and rewrites all of bin/, piling executable .backup.<ts> files into a
+        # directory that is on PATH. The bundled installer always uses --copy.
+        if [[ "$LINK_MODE" == "copy" ]]; then
+            if [[ -f "$target" && ! -L "$target" ]] && cmp -s "$source" "$target"; then
+                log_info "Already current: $name"
+                track_skipped "$name"
+                current=$((current + 1))
+                continue
+            fi
+        elif [[ -L "$target" ]]; then
             current_target=$(readlink "$target")
             if [[ "$current_target" == "$source" ]]; then
                 log_info "Already linked: $name"

--- a/modules/scripts.sh
+++ b/modules/scripts.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+# scripts.sh - Personal CLI scripts installation
+# Can be run standalone or sourced by install.sh
+
+# ==============================================================================
+# Standalone execution support
+# ==============================================================================
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    source "$SCRIPT_DIR/../lib/core.sh"
+    source "$SCRIPT_DIR/../lib/platform.sh"
+    detect_platform
+    setup_package_manager
+fi
+
+# ==============================================================================
+# Configuration
+# ==============================================================================
+# ~/.local/bin is preferred over ~/.scripts: it precedes ~/.scripts on PATH, so
+# linking here overrides an older copy (e.g. one shared over NFS) without having
+# to delete it. Removing the link rolls straight back to that copy.
+readonly SCRIPTS_BIN_DIR="$HOME/.local/bin"
+
+# ==============================================================================
+# Installation Functions
+# ==============================================================================
+
+install_scripts() {
+    log_info "Starting personal scripts installation..."
+
+    local root_dir
+    root_dir=$(get_root_dir)
+    local source_dir="$root_dir/bin"
+
+    if [[ ! -d "$source_dir" ]]; then
+        log_error "Scripts directory not found at: $source_dir"
+        return 1
+    fi
+
+    print_section "Linking personal scripts"
+
+    if [[ "$DRY_RUN" != "true" ]]; then
+        mkdir -p "$SCRIPTS_BIN_DIR"
+    fi
+
+    local linked=0 skipped=0
+    local source target name current_target
+
+    for source in "$source_dir"/*; do
+        [[ -f "$source" ]] || continue
+
+        name="$(basename "$source")"
+        target="$SCRIPTS_BIN_DIR/$name"
+
+        # Short-circuit if it already points at our repo source
+        if [[ -L "$target" ]]; then
+            current_target=$(readlink "$target")
+            if [[ "$current_target" == "$source" ]]; then
+                log_info "Already linked: $name"
+                track_skipped "$name"
+                skipped=$((skipped + 1))
+                continue
+            fi
+        fi
+
+        # A stale link or a stray copy in ~/.local/bin should give way to the
+        # repo version; backup_and_link keeps a backup of any real file.
+        FORCE=true backup_and_link "$source" "$target"
+        track_installed "$name"
+        linked=$((linked + 1))
+    done
+
+    log_success "Personal scripts configured ($linked linked, $skipped already current)"
+
+    if [[ ":$PATH:" != *":$SCRIPTS_BIN_DIR:"* ]]; then
+        log_warn "$SCRIPTS_BIN_DIR is not on PATH; add it to use these scripts"
+    fi
+}
+
+# ==============================================================================
+# Standalone Execution
+# ==============================================================================
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    setup_error_handling
+    install_scripts
+fi

--- a/modules/scripts.sh
+++ b/modules/scripts.sh
@@ -43,13 +43,39 @@ install_scripts() {
         mkdir -p "$SCRIPTS_BIN_DIR"
     fi
 
-    local linked=0 skipped=0
+    local linked=0 current=0 skipped=0 pruned=0
     local source target name current_target
+
+    # A script dropped from bin/ leaves its link behind, dangling on PATH.
+    # Only links that point into our own bin/ are considered.
+    for target in "$SCRIPTS_BIN_DIR"/*; do
+        [[ -L "$target" ]] || continue
+        current_target=$(readlink "$target")
+        [[ "$current_target" == "$source_dir"/* ]] || continue
+        [[ -e "$current_target" ]] && continue
+
+        if [[ "$DRY_RUN" == "true" ]]; then
+            log_info "[DRY-RUN] Would remove stale link: $(basename "$target")"
+        else
+            rm -f "$target"
+            log_info "Removed stale link: $(basename "$target")"
+        fi
+        pruned=$((pruned + 1))
+    done
 
     for source in "$source_dir"/*; do
         [[ -f "$source" ]] || continue
 
         name="$(basename "$source")"
+
+        # bin/ is a PATH directory, so anything without the execute bit would
+        # link in as an unrunnable command. Say so rather than linking it.
+        if [[ ! -x "$source" ]]; then
+            log_warn "Not executable, skipping: $name (chmod +x to install it)"
+            skipped=$((skipped + 1))
+            continue
+        fi
+
         target="$SCRIPTS_BIN_DIR/$name"
 
         # Short-circuit if it already points at our repo source
@@ -58,7 +84,7 @@ install_scripts() {
             if [[ "$current_target" == "$source" ]]; then
                 log_info "Already linked: $name"
                 track_skipped "$name"
-                skipped=$((skipped + 1))
+                current=$((current + 1))
                 continue
             fi
         fi
@@ -70,7 +96,7 @@ install_scripts() {
         linked=$((linked + 1))
     done
 
-    log_success "Personal scripts configured ($linked linked, $skipped already current)"
+    log_success "Personal scripts configured ($linked linked, $current current, $skipped skipped, $pruned stale removed)"
 
     if [[ ":$PATH:" != *":$SCRIPTS_BIN_DIR:"* ]]; then
         log_warn "$SCRIPTS_BIN_DIR is not on PATH; add it to use these scripts"

--- a/scripts/bundle.sh
+++ b/scripts/bundle.sh
@@ -89,6 +89,13 @@ while IFS= read -r file; do
     embed_file "$file"
 done < <(find "$SCRIPT_DIR/configs" -type f | LC_ALL=C sort)
 
+# Scripts that the `scripts` component links onto PATH.
+if [[ -d "$SCRIPT_DIR/bin" ]]; then
+    while IFS= read -r file; do
+        embed_file "$file"
+    done < <(find "$SCRIPT_DIR/bin" -type f | LC_ALL=C sort)
+fi
+
 # Runtime/capture helpers used by the AI-agent modules.
 for helper_dir in "$SCRIPT_DIR/scripts/claude" "$SCRIPT_DIR/scripts/codex"; do
     [[ -d "$helper_dir" ]] || continue


### PR DESCRIPTION
## Summary

- add a `scripts` component that links `bin/` into `~/.local/bin` via `backup_and_link`
- rewrite `subd` (v2): direct argv exec, exit-code propagation, `--parallel`, `--only-git`, `--timeout`, `--dry-run`
- fix the migrated scripts for PATH and macOS before publishing them
- keep work-specific scripts out of this repo since it is public

## Why subd was rewritten

v1 ran every command through `$SHELL -i`, which cost ~880ms of rc/prompt startup per directory. The prompt noise that produced was stripped by a broad `sed` filter that also deleted real output — a line like `[2026-08-24 ERROR] db connection failed` never reached the terminal. It flattened the command into a string (`${COMMAND[*]}`), so quoting and globs were corrupted, and it always exited 0 no matter what the child commands did.

v2 execs argv directly with no shell in between and keeps `-i` as an opt-in for alias expansion. `--depth` is validated (`-d abc` previously ran nothing and reported success), failures propagate to the exit code, and colour is TTY-aware.

On a 26-directory tree, `git status --short` goes from 30.0s to 0.24s, or 0.05s with `--only-git --parallel`. Output is byte-identical to v1 once the prompt noise is removed.

## Portability

`set -u` makes bash 3.2 and 4.3 treat an empty array expansion as an unbound variable, and subd's `pre` array is empty whenever `--timeout` is unset — every default invocation. macOS ships bash 3.2 and the `scripts` component is part of `--all`, so subd died on the first directory of every macOS install. Possibly-empty arrays now expand as `${arr[@]+"${arr[@]}"}`, and `wait -n` (bash 4.3+) falls back to batch waiting. Verified on 3.2.57, 4.3.48, 4.4.23 and 5.0.18.

## Review pass

A review of the branch turned up several things worth calling out, all fixed here:

- `install_scripts` returned 1 when `bin/` was missing; under install.sh's `set -euo pipefail` and ERR trap that aborted the whole run, so `./install.sh scripts ssh` exited 1 with ssh never reaching its module. `modules/ssh.sh:76` already handles the same case with `log_warn` + `return 0`.
- `bundle.sh` embedded `install.sh`, `lib/`, `modules/` and `configs/` but not `bin/` — the bundled installer shipped `modules/scripts.sh` with nothing to link, which is the failure its own comment warns about.
- The idempotence check only recognised symlinks, so under `--copy` (which `bundle.sh` always passes) every re-run backed up and rewrote all of `bin/`, leaving executable `.backup.<ts>` files in a PATH directory.
- Dropping a script from `bin/` left its symlink behind, dangling on PATH; re-running the component now prunes those instead of accumulating them.
- In subd, the `gitstatus` branch of the `-i` noise filter had no anchor, so any line containing that substring was dropped — the same silent-deletion defect v2 was meant to end. Child commands also inherited subd's own stdin, so the first directory drained it and the rest read nothing, differing from parallel mode; and "no matching directories" returned 0, reporting success for a run that executed nothing (now 3, as grep does).

## Hardening the migrated scripts

The scripts came over from `~/.scripts` unchanged. Linking them onto PATH under a component that also runs on macOS made their existing gaps reachable:

- `mkln` built relative links with `realpath --relative-to`, a GNU coreutils flag macOS lacks, and reported success while producing empty link targets. An empty source directory also left a link named `*`.
- `machine-info` assumed `lscpu`, `free` and `nvidia-smi` all exist, failed its core arithmetic without lscpu, printed an empty `GPU: ()` without nvidia-smi, and mangled every GPU model after the first on heterogeneous hosts.
- `pip-install.sh` never validated its argument, so a bare invocation expanded `"$TARGET_DIR"/*` to `/*` and ran `pip install -e` against every top-level directory. It also discarded pip's diagnostics and always exited 0.
- `get_audio_duration.sh` emitted a CSV row for the unexpanded glob when a directory held no `.wav`.
- `mp4-to-wav.sh` exited 0 after failing every conversion.

## Scope

`bin/` holds seven general-purpose scripts. The callabo and rt-* tooling stays out, along with `install.sh` (wired to internal NFS and `/opt/tools` paths, and destructive under `--overwrite`), `ssh-list` (keyed to office/IDC host groups), and `slack`/`ntfy` (carry endpoint values).

`~/.local/bin` precedes `~/.scripts` on PATH, so these links override the copy shared over NFS without deleting it; removing a link rolls back to it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)