### PR TITLE
fix(nvim): give bootstrapped lazy.nvim a branch, and wire the config up on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -659,6 +659,26 @@ parsers.
 > `git restore configs/nvim/lazy-lock.json` if it looks short. A line-ending-only diff
 > is normal and expected: lazy writes LF, `core.autocrlf` checks out CRLF.
 
+### Repairing an existing lazy.nvim install
+
+The bootstrap in `lua/config/lazy.lua` runs only when `lazypath` does not exist, so
+fixing it does **not** heal a machine where lazy.nvim was already installed with a
+detached HEAD. Such an install keeps truncating `lazy-lock.json` on every `Lazy!`
+command. Check and repair:
+
+```sh
+cd "${XDG_DATA_HOME:-$HOME/.local/share}/nvim/lazy/lazy.nvim"   # Windows: %LOCALAPPDATA%\nvim-data\lazy\lazy.nvim
+git rev-parse --abbrev-ref HEAD     # "HEAD" means detached — needs repairing
+git checkout -B main HEAD           # same commit, now on a branch
+```
+
+To find out whether a machine is affected at all, ask lazy.nvim which plugin it cannot
+name a branch for:
+
+```sh
+nvim --headless -c 'lua local G=require("lazy.manage.git") for _,p in pairs(require("lazy.core.config").plugins) do if p._.installed and not p._.is_local then local i=G.info(p.dir) if not i or not (i.branch or G.get_branch(p)) then print("no branch: "..p.name) end end end' -c 'qa!'
+```
+
 > [!NOTE]
 > LazyVim needs NeoVim 0.11 or newer (`modules/editor.sh` pins 0.11.2). Check with
 > `nvim --version`; a `nvim --version` that works proves only that the editor is

--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Components:
 |-----------|-------------|
 | [NeoVim](https://neovim.io/) | Hyperextensible Vim-based editor |
 | [LazyVim](https://www.lazyvim.org/) | Fast, modern Neovim setup powered by lazy.nvim |
+| [tree-sitter CLI](https://github.com/tree-sitter/tree-sitter) | Builds nvim-treesitter parsers (Windows: `npm i -g tree-sitter-cli`, no winget package) |
 
 ### Terminal
 | Component | Description |
@@ -616,6 +617,53 @@ The techniques, in order of what they were worth:
 > per-line costs, and inserting `[Stopwatch]` marks at each section header gives
 > per-section ones. Both were needed here: the line-level view found the PATH scan,
 > the section view found that starship was still spawning a second process.
+
+## NeoVim Configuration (Windows)
+
+`configs/nvim/` needs no Windows variant — nothing in it is POSIX-specific. What it
+needs is to be *found*: NeoVim reads `%LOCALAPPDATA%\nvim` on Windows, so installing
+the binary alone (`winget install Neovim.Neovim`) leaves a stock editor with no
+plugins and no keymaps, which looks like a working install until you notice `vim` has
+none of your bindings.
+
+### How to apply
+
+```powershell
+winget install --id Neovim.Neovim
+npm install -g tree-sitter-cli          # nvim-treesitter compiles parsers with it
+New-Item -ItemType Junction -Path "$env:LOCALAPPDATA\nvim" `
+         -Target "$env:USERPROFILE\workspace\settings\configs\nvim"
+nvim --headless "+Lazy! install" +qa
+nvim --headless "+Lazy! restore" +qa
+```
+
+A **junction**, not a symlink: a directory junction needs no elevation and no
+Developer Mode, where `New-Item -ItemType SymbolicLink` needs one of them. It is the
+closest equivalent to the symlink `modules/editor.sh` makes at `~/.config/nvim`, and
+it keeps `lazy-lock.json` writable in place, so a plugin update on Windows shows up
+as a repo change exactly as it does on macOS and Linux.
+
+`Lazy! restore` after `Lazy! install` is what pins the 35 plugins to the commits in
+`lazy-lock.json` rather than to whatever is newest that day, so this machine matches
+the others.
+
+There is no winget package for the tree-sitter CLI; npm ships a prebuilt binary,
+where `cargo install tree-sitter-cli` would compile it. Without it `mason.nvim`
+reports `Failed to install tree-sitter-cli` and `nvim-treesitter` cannot build
+parsers.
+
+> [!WARNING]
+> `lazy-lock.json` is a tracked file reached through the junction, so lazy.nvim writes
+> into the repo. If lazy ever dies while writing it, the file is left truncated to
+> `{` — check `git status` in this repo after a plugin operation, and
+> `git restore configs/nvim/lazy-lock.json` if it looks short. A line-ending-only diff
+> is normal and expected: lazy writes LF, `core.autocrlf` checks out CRLF.
+
+> [!NOTE]
+> LazyVim needs NeoVim 0.11 or newer (`modules/editor.sh` pins 0.11.2). Check with
+> `nvim --version`; a `nvim --version` that works proves only that the editor is
+> installed, not that this config is loaded. To check that, run
+> `nvim --headless -c 'lua print(pcall(require, "lazyvim"))' -c 'qa!'`.
 
 ## Troubleshooting
 

--- a/configs/nvim/lua/config/lazy.lua
+++ b/configs/nvim/lua/config/lazy.lua
@@ -7,7 +7,13 @@ if not (vim.uv or vim.loop).fs_stat(lazypath) then
     { "git", "init", lazypath },
     { "git", "-C", lazypath, "remote", "add", "origin", lazyrepo },
     { "git", "-C", lazypath, "fetch", "--depth=1", "origin", lazyref },
-    { "git", "-C", lazypath, "checkout", "--detach", "FETCH_HEAD" },
+    -- `checkout -B main` rather than `--detach`: same pinned commit, but it leaves a
+    -- local branch behind. With a detached HEAD lazy.nvim has no branch to record for
+    -- itself, so writing the lockfile hits `assert(Git.get_branch(plugin))` in
+    -- lazy/manage/lock.lua and dies partway through — leaving lazy-lock.json
+    -- truncated to "{". Which is a tracked file, since the config directory is a
+    -- symlink (junction on Windows) into this repo.
+    { "git", "-C", lazypath, "checkout", "-B", "main", "FETCH_HEAD" },
   }
   for _, cmd in ipairs(commands) do
     local out = vim.fn.system(cmd)


### PR DESCRIPTION
## The bug

`configs/nvim/lua/config/lazy.lua` fetched the pinned lazy.nvim ref and then
`checkout --detach FETCH_HEAD`, which leaves **no local branch at all**.

lazy.nvim records a branch per plugin when it writes `lazy-lock.json`, so for itself it
hit `assert(Git.get_branch(plugin))` in `lazy/manage/lock.lua` and died partway through
the write — leaving `lazy-lock.json` truncated to a single `{`. That file is tracked and
the config directory is a symlink into this repo, so **every `Lazy! install` or
`Lazy! restore` corrupted a committed file.**

```
Lua :command callback: .../lazy/manage/lock.lua:28: assertion failed!
```

`checkout -B main` keeps the same pinned commit and leaves a branch behind — which is
what the committed lockfile already records for lazy.nvim (`"branch": "main"`).

## Windows

`configs/nvim/` needed no variant of its own; nothing in it is POSIX-specific. It needed
to be *found*. NeoVim reads `%LOCALAPPDATA%\nvim`, so `winget install Neovim.Neovim`
alone leaves a stock editor with no plugins and no keymaps:

```
init used        : C:\Users\jiun\AppData\Local\nvim/init.lua
exists?          : false
lazy.nvim loaded : false
LazyVim          : false
runtimepath dirs : 8
```

`nvim --version` working proves the editor is installed, not that this config is loaded
— an easy thing to mistake for a working setup.

A **junction**, not a symlink: directory junctions need neither elevation nor Developer
Mode, unlike `New-Item -ItemType SymbolicLink`, and it is the closest equivalent to the
symlink `modules/editor.sh` makes at `~/.config/nvim`. It also keeps `lazy-lock.json`
writable in place, so a plugin update on Windows shows up as a repo change exactly as it
does elsewhere.

Also documents the tree-sitter CLI, which has no winget package. Without it `mason.nvim`
reports `Failed to install tree-sitter-cli` and `nvim-treesitter` cannot build parsers;
npm ships a prebuilt binary where cargo would compile one.

## Verified on Windows 11 / NeoVim 0.12.5

| | |
| :--- | :--- |
| `Lazy! restore` | completes, no assertion |
| `lazy-lock.json` | valid JSON, pins unchanged |
| LazyVim | loads, all 35 plugins |
| `runtimepath` | 8 → 14 entries |
| leader | `<space>` |

The only remaining `checkhealth` noise is luarocks, which lazy itself marks ignorable
("no plugins require `luarocks`").

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016wukLAEPLBuWkhiFgZ7Xh8