### PR TITLE
fix(install): follow the remote's default branch instead of naming it

### DIFF
--- a/.gitea/workflows/release.yml
+++ b/.gitea/workflows/release.yml
@@ -25,7 +25,11 @@ name: Release
 on:
   push:
     branches:
+      # Both listed so the default branch can be renamed without a release gap:
+      # GitHub does not rewrite workflow triggers on rename, and a trigger naming a
+      # branch that no longer exists simply never fires.
       - master
+      - main
     tags:
       - 'v*'
     paths-ignore:

--- a/README.md
+++ b/README.md
@@ -379,7 +379,7 @@ settings/
 │   └── scripts.sh         #   Personal CLI scripts → ~/.local/bin
 ├── bin/                    # Personal CLI scripts (linked onto PATH)
 │   └── subd               #   Run a command across subdirectories
-├── worker/                 # Cloudflare Worker (settings.jiun.dev)
+├── worker/                 # Cloudflare Worker — written, never deployed (see below)
 │   ├── index.js           #   Proxy raw GitHub content
 │   └── wrangler.toml      #   Wrangler configuration
 ├── scripts/                # Build scripts
@@ -403,6 +403,27 @@ settings/
 └── .github/workflows/      # CI/CD
     └── release.yml         #   Auto-release on tag
 ```
+
+## How settings.jiun.dev is served
+
+**GitHub Pages, from the `gh-pages` branch** — not the Cloudflare Worker in `worker/`.
+That Worker was written but never deployed; the live responses carry
+`x-github-request-id` and Fastly's `via: 1.1 varnish`, and none of the `x-repo` header
+`worker/index.js` sets on every 200. `gh api repos/jiunbae/settings/pages` confirms
+`source: { branch: gh-pages, path: / }`. Cloudflare only proxies the domain.
+
+`gh-pages` holds three files: `CNAME`, `bootstrap.sh`, and `index.html` — where
+`index.html` is a byte-identical copy of `bootstrap.sh`, which is what makes
+`curl -LsSf https://settings.jiun.dev | bash` work with no path.
+
+> [!IMPORTANT]
+> `bootstrap.sh` therefore exists **twice**: the real one here on the default branch,
+> and the copy on `gh-pages` that is actually served. Nothing syncs them — no workflow
+> in `.gitea/`, `.github/` or `scripts/` references `gh-pages`. The copy went stale for
+> over five months once (live: 2026-02-22, repo: 2026-07-31), which meant the live
+> installer was missing the guard that refuses to `git reset --hard` over uncommitted
+> local changes. **After changing `bootstrap.sh`, copy it to both `bootstrap.sh` and
+> `index.html` on `gh-pages`.**
 
 ## Platform Support
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -15,7 +15,6 @@ set -euo pipefail
 # Configuration
 # ==============================================================================
 REPO_URL="https://github.com/jiunbae/settings"
-REPO_NAME="settings"
 INSTALL_DIR="${SETTINGS_INSTALL_DIR:-$HOME/.settings}"
 
 # Colors
@@ -83,7 +82,13 @@ download_with_git() {
             log_warn "Discarding local changes because SETTINGS_FORCE_UPDATE=true"
         fi
         git fetch origin
-        git reset --hard origin/master
+        # Follow whatever the remote's default branch is called rather than naming it.
+        # GitHub does not redirect git operations that use an old branch name after a
+        # rename, so a hardcoded `origin/master` leaves every existing clone broken the
+        # moment the default branch is renamed. `set-head -a` re-asks the server and
+        # rewrites origin/HEAD, creating it if an older clone lacks it.
+        git remote set-head origin -a >/dev/null 2>&1 || true
+        git reset --hard origin/HEAD
     else
         git clone --depth 1 "$REPO_URL.git" "$INSTALL_DIR"
     fi
@@ -94,7 +99,9 @@ download_with_git() {
 download_with_tarball() {
     log_info "Downloading via tarball (git not available)..."
 
-    local tarball_url="$REPO_URL/archive/refs/heads/master.tar.gz"
+    # /archive/HEAD.tar.gz follows the repository's default branch, so this survives a
+    # branch rename where /archive/refs/heads/<name>.tar.gz would 404.
+    local tarball_url="$REPO_URL/archive/HEAD.tar.gz"
     local tmp_dir=$(mktemp -d)
 
     # Download
@@ -104,9 +111,19 @@ download_with_tarball() {
         wget -qO- "$tarball_url" | tar -xz -C "$tmp_dir"
     fi
 
+    # The HEAD tarball's single top-level directory is named after the commit sha
+    # (settings-<sha>), not the branch, so it has to be discovered rather than guessed.
+    local extracted
+    extracted=$(find "$tmp_dir" -mindepth 1 -maxdepth 1 -type d | head -n 1)
+    if [[ -z "$extracted" ]]; then
+        log_error "Tarball did not contain a directory; download likely failed"
+        rm -rf "$tmp_dir"
+        exit 1
+    fi
+
     # Move to install directory
     rm -rf "$INSTALL_DIR"
-    mv "$tmp_dir/$REPO_NAME-master" "$INSTALL_DIR"
+    mv "$extracted" "$INSTALL_DIR"
     rm -rf "$tmp_dir"
 
     log_success "Downloaded to $INSTALL_DIR"

--- a/scripts/sync-gh-pages.sh
+++ b/scripts/sync-gh-pages.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+# sync-gh-pages.sh - publish bootstrap.sh to the branch that actually serves it.
+#
+# settings.jiun.dev is GitHub Pages from `gh-pages`, not the Worker in worker/ (see
+# the README). That branch carries its own copy of bootstrap.sh, plus index.html as a
+# byte-identical duplicate so `curl -LsSf https://settings.jiun.dev | bash` works with
+# no path. Nothing syncs them automatically, and the copy once went stale for over
+# five months - long enough that the live installer was missing the guard that refuses
+# to `git reset --hard` over uncommitted local changes.
+#
+# Run this after committing any change to bootstrap.sh.
+#
+#   scripts/sync-gh-pages.sh              # show what would change
+#   scripts/sync-gh-pages.sh --push       # commit and push to gh-pages
+
+set -euo pipefail
+
+PUSH=false
+[[ "${1:-}" == "--push" ]] && PUSH=true
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+cd "$ROOT"
+
+# Source the COMMITTED blob, not the working copy. Two reasons: gh-pages should only
+# ever mirror a committed state, and on a machine with core.autocrlf=true the working
+# copy has CRLF line endings - publishing those would ship a bootstrap.sh whose
+# shebang is `#!/bin/bash\r`, which bash will not run.
+SRC=$(mktemp); trap 'rm -f "$SRC"' EXIT
+git show HEAD:bootstrap.sh > "$SRC" 2>/dev/null || {
+    echo "bootstrap.sh not found at HEAD - commit it first" >&2; exit 1; }
+
+if grep -q $'\r' "$SRC"; then
+    echo "HEAD:bootstrap.sh contains CR bytes; refusing to publish" >&2
+    exit 1
+fi
+
+# Never publish a script that does not parse.
+bash -n "$SRC" || { echo "bootstrap.sh has syntax errors; refusing to publish" >&2; exit 1; }
+
+git fetch origin gh-pages --quiet
+
+if git show origin/gh-pages:bootstrap.sh > /tmp/.ghp-live 2>/dev/null && \
+   cmp -s /tmp/.ghp-live "$SRC"; then
+    rm -f /tmp/.ghp-live
+    echo "gh-pages is already up to date with HEAD:bootstrap.sh"
+    exit 0
+fi
+
+echo "gh-pages bootstrap.sh differs from HEAD:bootstrap.sh:"
+diff /tmp/.ghp-live "$SRC" || true
+rm -f /tmp/.ghp-live
+echo
+
+if [[ "$PUSH" != "true" ]]; then
+    echo "Re-run with --push to publish."
+    exit 0
+fi
+
+# Work in a detached worktree so the current branch and index are untouched.
+WT=$(mktemp -d)
+cleanup() { git worktree remove --force "$WT" 2>/dev/null || true; rm -rf "$WT" "$SRC"; }
+trap cleanup EXIT
+git worktree add --quiet --detach "$WT" origin/gh-pages
+SHA=$(git rev-parse --short HEAD)
+cd "$WT"
+
+# index.html is a duplicate of the script on purpose: Pages serves it for a pathless
+# request, which is what the documented one-liner relies on.
+cp "$SRC" bootstrap.sh
+cp "$SRC" index.html
+
+if git diff --quiet; then
+    echo "nothing to commit"
+    exit 0
+fi
+
+git add bootstrap.sh index.html
+git commit --quiet -m "chore(pages): sync bootstrap.sh from $SHA"
+git push --quiet origin HEAD:gh-pages
+echo "pushed to gh-pages: $(git rev-parse --short HEAD)"

--- a/worker/index.js
+++ b/worker/index.js
@@ -1,6 +1,14 @@
 /**
  * Cloudflare Worker — settings.jiun.dev
  *
+ * NOT DEPLOYED. settings.jiun.dev is served by GitHub Pages from the `gh-pages`
+ * branch; Cloudflare only proxies the domain. Live responses carry GitHub/Fastly
+ * headers and never the `x-repo` header this file sets, and
+ * `gh api repos/jiunbae/settings/pages` reports `source: { branch: gh-pages }`.
+ * Keeping this as a record of the alternative; if it is ever deployed, note that
+ * BRANCH below pins a branch name and that raw.githubusercontent.com URLs are not
+ * redirected after a branch rename.
+ *
  * Proxies the bootstrap installer from GitHub raw content.
  *
  * Usage:


### PR DESCRIPTION
Groundwork for renaming the default branch to `main`. GitHub's own docs are explicit
that **raw file URLs are not redirected** and that it **performs no redirect for a
`git pull` using the previous branch name** — so every place that names `master` has to
stop naming it *before* the rename, or existing installs break.

## bootstrap.sh

| before | after | why |
| :--- | :--- | :--- |
| `git reset --hard origin/master` | `git remote set-head origin -a` then `reset --hard origin/HEAD` | `set-head -a` re-asks the server and rewrites `origin/HEAD`, creating it when an older clone lacks it |
| `/archive/refs/heads/master.tar.gz` | `/archive/HEAD.tar.gz` | follows the default branch; the old URL would 404 after a rename |
| `mv "$tmp_dir/$REPO_NAME-master"` | discover the single top-level dir | the HEAD tarball's directory is `settings-<sha>`, not `settings-<branch>` |

`REPO_NAME` existed only to build that guessed directory name, so it is gone. A
missing extracted directory is now an error rather than a confusing `mv` failure.

Both paths were tested end to end: the tarball path discovered
`settings-6c83c24d5811bbeee44c342bd4179f083af373a4` and installed correctly, and the
git path recovered from an `origin/HEAD` deliberately pointed at the wrong branch
(`'origin/HEAD' has changed from 'gh-pages' and now points to 'master'`).

## release.yml

Triggers on `master` **and** `main`. GitHub does not rewrite workflow triggers on a
rename, and a trigger naming a branch that no longer exists simply never fires.

## Two documentation defects found while checking what would break

**`worker/` has never been deployed.** `settings.jiun.dev` is GitHub Pages from
`gh-pages`; Cloudflare only proxies the domain. Live responses carry
`x-github-request-id` and Fastly's `via: 1.1 varnish`, and never the `x-repo` header
`worker/index.js` sets on every 200. `gh api repos/jiunbae/settings/pages` reports
`source: { branch: gh-pages, path: / }`. The README described `worker/` as what serves
the domain; it and the file header now say otherwise. Its `BRANCH = "master"` was
therefore never a live dependency.

**`gh-pages` carries its own copy of `bootstrap.sh`** — duplicated again as
`index.html`, which is what makes the pathless one-liner work — and nothing syncs
them. No workflow in `.gitea/`, `.github/` or `scripts/` references `gh-pages`.

> The copy had been stale since **2026-02-22** against a repo version from
> **2026-07-31**. The live installer was missing `a3382bc`, the guard that refuses to
> `git reset --hard` over uncommitted local changes — so `curl … | bash` over an
> existing install could silently discard the user's edits.

`scripts/sync-gh-pages.sh` makes publishing one command. It sources the **committed
blob**, not the working copy: with `core.autocrlf=true` the working copy has CRLF, and
publishing that would ship a `bootstrap.sh` whose shebang is `#!/bin/bash\r`, which
bash will not run. It refuses to publish CR bytes or a script that fails `bash -n`, and
works in a detached worktree so the current branch is untouched.

## After merge

1. `scripts/sync-gh-pages.sh --push` — fixes the live installer
2. rename `master` → `main`
3. Gitea's `default_branch` (the Gitea copy is a read-only pull mirror of GitHub, so it
   will pick up `main` and prune `master`, but its default branch setting is its own)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016wukLAEPLBuWkhiFgZ7Xh8