### PR TITLE
chore: drop the last references to the old master branch

### DIFF
--- a/.gitea/workflows/release.yml
+++ b/.gitea/workflows/release.yml
@@ -18,17 +18,16 @@ name: Release
 # publish half is skipped rather than failed.
 #
 # Note the mirror makes this workflow fire twice per release: once for the
-# master push that creates the tag, and again when the new tag syncs back from
-# GitHub. The second run finds the release already present and exits early.
+# push to the default branch that creates the tag, and again when the new tag syncs
+# back from GitHub. The second run finds the release already present and exits early.
 # The old GitHub workflow behaved the same way.
 
 on:
   push:
     branches:
-      # Both listed so the default branch can be renamed without a release gap:
-      # GitHub does not rewrite workflow triggers on rename, and a trigger naming a
-      # branch that no longer exists simply never fires.
-      - master
+      # Must match the branch name on the Gitea side, which mirrors GitHub's default.
+      # A trigger naming a branch that does not exist simply never fires, and GitHub
+      # does not rewrite workflow triggers when a branch is renamed.
       - main
     tags:
       - 'v*'

--- a/worker/index.js
+++ b/worker/index.js
@@ -24,7 +24,7 @@
  */
 
 const REPO = "jiunbae/settings";
-const BRANCH = "master";
+const BRANCH = "main";
 const RAW_BASE = `https://raw.githubusercontent.com/${REPO}/${BRANCH}`;
 
 // Cache TTL in seconds (5 minutes — balance between freshness and speed)


### PR DESCRIPTION
Follow-up to the `master` → `main` rename. None of these affect behaviour — which is
why they were left out of the rename itself — but all three now name a branch that no
longer exists.

| file | change |
| :--- | :--- |
| `.gitea/workflows/release.yml` | trigger `[master, main]` → `[main]`; both were listed deliberately so the rename could happen without a release gap |
| `.gitea/workflows/release.yml` | comment said "the **master** push that creates the tag" → "the push to the default branch", which is what it meant |
| `worker/index.js` | `BRANCH = "master"` → `"main"` |

`worker/index.js` is **not deployed** (`settings.jiun.dev` is GitHub Pages from
`gh-pages`), so its branch constant was never live. Leaving wrong data in it just
invites someone to trust it later. The new value resolves —
`raw.githubusercontent.com/jiunbae/settings/main/bootstrap.sh` returns `200`.

`bootstrap.sh` keeps its one remaining mention of `origin/master` on purpose: that is
the comment explaining why the hardcoded ref was replaced.

## Verified

- workflow YAML parses: `push.branches == ['main']`, `push.tags == ['v*']`, job `release` with all 7 steps intact
- `node --check worker/index.js` passes
- no `master` left in tracked files except the explanatory comment (excluding `configs/.p10k.zsh`, which cites upstream URLs and sample output, and `scripts/mac-mini-k3s/`, which means a k3s master node)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016wukLAEPLBuWkhiFgZ7Xh8