### PR TITLE
docs: split the README into a landing page and docs/ guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ git clone https://github.com/jiunbae/settings.git && cd settings
 
 | Area | Components |
 | :--- | :--- |
-| **Shell** | [zsh](https://www.zsh.org/) + [zinit](https://github.com/zdharma-continuum/zinit) + [Powerlevel10k](https://github.com/romkatv/powerlevel10k) · PowerShell 7 + [starship](https://starship.rs/) + [PSFzf](https://github.com/kelleyma49/PSFzf) on Windows |
+| **Shell** | [zsh](https://www.zsh.org/) + [zinit](https://github.com/zdharma-continuum/zinit) + [Powerlevel10k](https://github.com/romkatv/powerlevel10k), with [autosuggestions](https://github.com/zsh-users/zsh-autosuggestions) and [fast-syntax-highlighting](https://github.com/z-shell/fast-syntax-highlighting) · PowerShell 7 + [starship](https://starship.rs/) + [PSFzf](https://github.com/kelleyma49/PSFzf) on Windows |
 | **Editor** | [NeoVim](https://neovim.io/) + [LazyVim](https://www.lazyvim.org/), with the [tree-sitter CLI](https://github.com/tree-sitter/tree-sitter) for parsers |
 | **Multiplexer** | [tmux](https://github.com/tmux/tmux) + [TPM](https://github.com/tmux-plugins/tpm) · [zellij](https://zellij.dev/) · [rmux](https://github.com/Helvesec/rmux) on Windows |
 | **CLI tools** | [eza](https://github.com/eza-community/eza) `ls` · [fd](https://github.com/sharkdp/fd) `find` · [bat](https://github.com/sharkdp/bat) `cat` · [ripgrep](https://github.com/BurntSushi/ripgrep) `grep` · [fzf](https://github.com/junegunn/fzf) |
@@ -110,8 +110,22 @@ Options:
   -h, --help          Show help message
 
 Components:
-  base zsh nvim tmux zellij rust uv tools tools-extra
-  ssh hishtory hammerspoon codex claude cship scripts
+  base          Basic packages (curl, wget, git, build-essential)
+  zsh           Zsh + zinit + Powerlevel10k
+  nvim          NeoVim + LazyVim
+  tmux          tmux + TPM (terminal multiplexer)
+  zellij        zellij (modern terminal multiplexer)
+  rust          Rust toolchain + cargo-binstall
+  uv            uv (fast Python package manager)
+  tools         CLI tools (eza, fd, bat, ripgrep, fzf)
+  tools-extra   Extra CLI tools (delta, dust, procs, bottom)
+  ssh           SSH config (copy only, not symlinked)
+  hishtory      hishtory (better shell history with sync support)
+  hammerspoon   Hammerspoon (macOS-only: window manager + keybindings)
+  codex         Codex CLI/App config, hooks, and notify chain
+  claude        Claude Code settings, hooks, skill index, memory, MCP
+  cship         cship + Starship (fast Claude Code statusline)
+  scripts       Personal CLI scripts linked into ~/.local/bin
 ```
 
 ```bash
@@ -147,8 +161,10 @@ settings/
 │   ├── nvim/ zellij/ powershell/ windows-terminal/
 │   └── claude/ codex/ cship/ hishtory/
 ├── bin/                    # Personal CLI scripts, linked onto PATH
+│   └── windows/            #   Windows-only; install.sh never sees this dir
 ├── scripts/                # Build and maintenance helpers
 ├── docs/                   # The guides linked below
+├── .gitea/workflows/       # Releases run on the self-hosted Gitea runner
 └── worker/                 # Cloudflare Worker — written, never deployed
 ```
 
@@ -156,6 +172,7 @@ settings/
 
 | | |
 | :--- | :--- |
+| [components.md](docs/components.md) | hishtory sync, Hammerspoon permissions, the managed Codex config |
 | [windows.md](docs/windows.md) | rmux, PowerShell, NeoVim, Windows Terminal, Nextcloud upload |
 | [powershell.md](docs/powershell.md) | How the PowerShell profile went from 1354ms to 394ms |
 | [agent-state.md](docs/agent-state.md) | Restoring Claude Code / Codex state on a new machine |

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Settings
 
-[![Platform](https://img.shields.io/badge/platform-Linux%20%7C%20macOS%20%7C%20WSL-blue)]()
-[![Shell](https://img.shields.io/badge/shell-zsh-green)]()
+[![Platform](https://img.shields.io/badge/platform-Linux%20%7C%20macOS%20%7C%20Windows%20%7C%20WSL-blue)]()
+[![Shell](https://img.shields.io/badge/shell-zsh%20%7C%20pwsh-green)]()
 [![License](https://img.shields.io/badge/license-MIT-yellow)]()
 
 Modern dotfiles installer with animated progress display.
@@ -36,43 +36,60 @@ Post-install: exec zsh
 
 ## Quick Start
 
-### One-Line Install (Recommended)
-
 ```bash
-# Install everything
+# everything
 curl -LsSf https://settings.jiun.dev | bash -s -- --all
 
-# Install specific components
+# pick components
 curl -LsSf https://settings.jiun.dev | bash -s -- zsh nvim tmux
 
-# Interactive selector
+# choose from a menu
 curl -LsSf https://settings.jiun.dev | bash -s -- --interactive
 ```
 
-### Manual Clone
+Or clone it first:
 
 ```bash
-git clone https://github.com/jiunbae/settings.git
-cd settings
+git clone https://github.com/jiunbae/settings.git && cd settings
 ./install.sh --all
 ```
 
-### Presets
+| Preset | Installs |
+| :--- | :--- |
+| `--all` | everything |
+| `--core` | base, zsh, nvim, tmux, tools |
+| `--basic` | base, zsh, nvim, tmux |
+| *(no args)* | interactive selector |
 
-```bash
-./install.sh              # Interactive selector (pick components in a menu)
-./install.sh --all        # Install everything
-./install.sh --core       # Core dev environment (base, zsh, nvim, tmux, tools)
-./install.sh --basic      # Minimal (base, zsh, nvim, tmux)
-```
+## What's inside
 
-## Features
+| Area | Components |
+| :--- | :--- |
+| **Shell** | [zsh](https://www.zsh.org/) + [zinit](https://github.com/zdharma-continuum/zinit) + [Powerlevel10k](https://github.com/romkatv/powerlevel10k) · PowerShell 7 + [starship](https://starship.rs/) + [PSFzf](https://github.com/kelleyma49/PSFzf) on Windows |
+| **Editor** | [NeoVim](https://neovim.io/) + [LazyVim](https://www.lazyvim.org/), with the [tree-sitter CLI](https://github.com/tree-sitter/tree-sitter) for parsers |
+| **Multiplexer** | [tmux](https://github.com/tmux/tmux) + [TPM](https://github.com/tmux-plugins/tpm) · [zellij](https://zellij.dev/) · [rmux](https://github.com/Helvesec/rmux) on Windows |
+| **CLI tools** | [eza](https://github.com/eza-community/eza) `ls` · [fd](https://github.com/sharkdp/fd) `find` · [bat](https://github.com/sharkdp/bat) `cat` · [ripgrep](https://github.com/BurntSushi/ripgrep) `grep` · [fzf](https://github.com/junegunn/fzf) |
+| **CLI extras** | [delta](https://github.com/dandavison/delta) `git diff` · [dust](https://github.com/bootandy/dust) `du` · [procs](https://github.com/dalance/procs) `ps` · [bottom](https://github.com/ClementTsang/bottom) `htop` |
+| **Toolchains** | [Rust](https://www.rust-lang.org/) + [cargo-binstall](https://github.com/cargo-bins/cargo-binstall) · [uv](https://github.com/astral-sh/uv) · [fnm](https://github.com/Schniz/fnm) |
+| **AI agents** | Claude Code · Codex · [cship](https://github.com/stephenleo/cship) statusline — see [agent-state.md](docs/agent-state.md) |
+| **History** | [hishtory](https://github.com/ddworken/hishtory) — context, search, cross-device sync |
+| **macOS** | [Hammerspoon](https://www.hammerspoon.org/) — window, screen and keyboard automation |
 
-- **Modular Architecture** - Install only what you need
-- **Cross-Platform** - Linux, macOS, and WSL support
-- **Progress Display** - Animated spinner with progress bar
-- **Dry-Run Mode** - Preview changes before applying
-- **Idempotent** - Safe to run multiple times
+Every component is independent, safe to re-run, and has a `--dry-run`.
+
+## Platform Support
+
+| Platform | Package manager | Architecture | Installer |
+| :--- | :--- | :--- | :--- |
+| Ubuntu/Debian | apt | x86_64, arm64 | `install.sh` |
+| macOS | Homebrew | Intel, Apple Silicon | `install.sh` |
+| WSL | apt | x86_64 | `install.sh` |
+| Windows | winget | x86_64 | manual — [windows.md](docs/windows.md) |
+
+> [!NOTE]
+> `install.sh` does not run on Windows: `lib/platform.sh` `detect_platform` exits on
+> anything that is not Linux or Darwin. Windows configs live in `configs/` and are
+> placed by hand, following the same pattern as `configs/windows-terminal/`.
 
 ## Usage
 
@@ -93,635 +110,68 @@ Options:
   -h, --help          Show help message
 
 Components:
-  base          Basic packages (curl, wget, git, build-essential)
-  zsh           Zsh + zinit + Powerlevel10k
-  nvim          NeoVim + LazyVim
-  tmux          tmux + TPM (terminal multiplexer)
-  zellij        zellij (modern terminal multiplexer)
-  rust          Rust toolchain + cargo-binstall
-  uv            uv (fast Python package manager)
-  tools         CLI tools (eza, fd, bat, ripgrep, fzf)
-  tools-extra   Extra CLI tools (delta, dust, procs, bottom)
-  ssh           SSH config (copy only, not symlinked)
-  hishtory      hishtory (better shell history with sync support)
-  hammerspoon   Hammerspoon (macOS-only: window manager + keybindings)
-  codex         Codex CLI/App config, hooks, and notify chain
-  claude        Claude Code settings, hooks, skill index, memory, MCP
-  cship         cship + Starship (fast Claude Code statusline)
-  scripts       Personal CLI scripts linked into ~/.local/bin
+  base zsh nvim tmux zellij rust uv tools tools-extra
+  ssh hishtory hammerspoon codex claude cship scripts
 ```
-
-## Components
-
-### Shell Environment
-| Component | Description |
-|-----------|-------------|
-| [Zsh](https://www.zsh.org/) | Modern shell |
-| [zinit](https://github.com/zdharma-continuum/zinit) | Fast plugin manager |
-| [Powerlevel10k](https://github.com/romkatv/powerlevel10k) | Fast, customizable prompt |
-| zsh-syntax-highlighting | Fish-like syntax highlighting |
-| zsh-autosuggestions | Fish-like autosuggestions |
-
-### Editor
-| Component | Description |
-|-----------|-------------|
-| [NeoVim](https://neovim.io/) | Hyperextensible Vim-based editor |
-| [LazyVim](https://www.lazyvim.org/) | Fast, modern Neovim setup powered by lazy.nvim |
-| [tree-sitter CLI](https://github.com/tree-sitter/tree-sitter) | Builds nvim-treesitter parsers (Windows: `npm i -g tree-sitter-cli`, no winget package) |
-
-### Terminal
-| Component | Description |
-|-----------|-------------|
-| [tmux](https://github.com/tmux/tmux) | Terminal multiplexer (default) |
-| [TPM](https://github.com/tmux-plugins/tpm) | Tmux plugin manager |
-| [zellij](https://zellij.dev/) | Terminal multiplexer (alternative) |
-| [Windows Terminal](https://aka.ms/terminal) | Modern terminal for Windows |
-| [rmux](https://github.com/Helvesec/rmux) | tmux-compatible multiplexer, native on Windows |
-| [starship](https://starship.rs/) | Cross-shell prompt (PowerShell; replaces Powerlevel10k) |
-| [PSFzf](https://github.com/kelleyma49/PSFzf) | fzf bindings for PSReadLine (PowerShell; stands in for fzf-tab) |
-
-### AI Coding Agents
-| Component | Description |
-|-----------|-------------|
-| Claude Code | `settings.json`, hooks, skill index and memory, symlinked to this repo — see [Restoring AI agent state](#restoring-ai-agent-state-on-a-new-machine) |
-| Codex | `config.toml` managed half, merged over local runtime state |
-| [cship](https://github.com/stephenleo/cship) | Claude Code statusline (Rust) — replaces ccstatusline: ~33ms vs ~1,250ms per render, ~18MB vs ~99MB peak RSS |
-| [Starship](https://starship.rs) | Required by cship for the `$directory` / `$git_branch` / `$git_metrics` / `$custom.worktree` passthrough segments |
-
-### Development Tools
-| Component | Description |
-|-----------|-------------|
-| [Rust](https://www.rust-lang.org/) | Systems programming language |
-| [cargo-binstall](https://github.com/cargo-bins/cargo-binstall) | Binary package installer |
-| [uv](https://github.com/astral-sh/uv) | Fast Python package manager (10-100x faster than pip) |
-
-### Modern CLI Tools
-
-**Basic tools** (`tools`):
-| Tool | Replaces | Description |
-|------|----------|-------------|
-| [eza](https://github.com/eza-community/eza) | `ls` | Modern ls with icons and git integration |
-| [fd](https://github.com/sharkdp/fd) | `find` | Simple, fast alternative to find |
-| [bat](https://github.com/sharkdp/bat) | `cat` | Cat with syntax highlighting |
-| [ripgrep](https://github.com/BurntSushi/ripgrep) | `grep` | Fast regex search tool |
-| [fzf](https://github.com/junegunn/fzf) | - | Fuzzy finder |
-
-**Extra tools** (`tools-extra`):
-| Tool | Replaces | Description |
-|------|----------|-------------|
-| [delta](https://github.com/dandavison/delta) | `git diff` | Better git diff viewer |
-| [dust](https://github.com/bootandy/dust) | `du` | Intuitive disk usage |
-| [procs](https://github.com/dalance/procs) | `ps` | Modern process viewer |
-| [bottom](https://github.com/ClementTsang/bottom) | `htop` | System monitor |
-
-### Shell History
-| Component | Description |
-|-----------|-------------|
-| [hishtory](https://github.com/ddworken/hishtory) | Better shell history with context, search, and sync |
-
-### AI Coding Tools
-| Component | Description |
-|-----------|-------------|
-| codex | Managed Codex config template. Applies stable model/plugin/MCP/hook settings, disables legacy `~/.codex/hooks.json`, and preserves machine-local runtime sections such as project/hook trust, `notify`, TUI state, and desktop settings. |
-
-**hishtory features:**
-- Context-aware history (directory, exit code, duration)
-- Fuzzy search with `Ctrl+R`
-- E2E encrypted sync across machines
-- Self-hosted server support
-
-**Configuration (`~/.envs/hishtory.env`):**
-```bash
-# Self-hosted server (optional, local-only mode without this)
-export HISHTORY_SERVER="https://hishtory.example.com"
-
-# Secret key for cross-device sync (get from `hishtory status`)
-export HISHTORY_SECRET="your-secret-key-uuid"
-```
-
-Without `HISHTORY_SERVER`, hishtory runs in local-only mode.
-To sync across devices, use the same `HISHTORY_SECRET` on all machines.
-
-### macOS Automation
-| Component | Description |
-|-----------|-------------|
-| [Hammerspoon](https://www.hammerspoon.org/) | Lua-scriptable macOS automation (window/screen/keyboard) |
-
-**Installs via Homebrew Cask and symlinks `~/.hammerspoon/init.lua` to this repo.**
-Skipped automatically on Linux/WSL. Accessibility permission must be granted manually:
-System Settings → Privacy & Security → Accessibility → enable Hammerspoon.
-
-## Restoring AI agent state on a new machine
-
-Claude Code and Codex keep their configuration in different shapes, so this repo
-manages them differently. Follow the order below — step 2 must happen before
-step 3, because `configs/claude/settings.json` references hook scripts that live
-in the agent-skills repo.
 
 ```bash
-# 1. this repo
-git clone git@github.com:jiunbae/settings.git ~/personal/settings
-
-# 2. hook scripts referenced by Claude settings.json
-git clone git@github.com:jiunbae/agent-skills.git ~/personal/agent-skills
-
-# 3. shared skill/static-doc repo, then lay down ~/.agents/
-# private shared-skill repo — substitute your own remote
-git clone <private-agents-repo> ~/workspace/agents
-~/workspace/agents/scripts/install-static.sh
-~/workspace/agents/scripts/install-shims.sh
-
-# 4. external runtimes used by the managed hooks (examples)
-#    Install and log in to Claude Code and Codex through their official installers.
-brew install open330/tap/muxa             # or follow muxa's platform instructions
-npm install -g oh-my-prompt               # provides omp
-
-# 5. agents + statusline
-cd ~/personal/settings
-./install.sh claude cship codex
-
-# Restore Oh My Prompt's Codex notify entry after its own setup. Later Codex
-# config applies preserve this machine-local absolute command.
-omp install --cli codex
-
-# 6. private state — never in git
-#    - ~/.envs/*.env
-#    - ~/.config/muxa/config.toml
-#    - the gitignored personal files created from agents/*/*.sample.{md,yaml}
-#      (restore from a secure backup or replace every {{PLACEHOLDER}})
-#    - re-login instead of copying Claude/Codex credential files
-
-# 7. Codex directory trust is exact-path based and per-machine. The codex
-#    component installs this helper from scripts/codex/workspace-trust-sync.sh.
-~/.local/bin/codex-workspace-trust-sync
+./install.sh --dry-run --all       # preview, change nothing
+./install.sh -v zsh                # one component, verbose
+./install.sh --force zsh           # reinstall over an existing setup
+cat ~/.install.log                 # what actually happened
 ```
 
-The three Git clones restore versioned configuration and scripts. They cannot
-restore credentials, dashboard tokens, or the personalized `agents/static` and
-`agents/<workspace>/static` files because those are deliberately gitignored. A
-matching file count under `~/.agents` is therefore only a topology check; verify
-the contents and resolve the install-static placeholder warning before use.
-
-> [!WARNING]
-> These are personal settings for trusted workspaces. The managed Codex config
-> uses `approval_policy = "never"` with `sandbox_mode = "danger-full-access"`,
-> and Claude settings skip the dangerous-mode confirmation. Do not install them
-> unchanged on an untrusted repository or shared machine. The configured muxa,
-> Oh My Prompt, and prompt-logger hooks also receive agent lifecycle events or
-> prompt content; review those local tools and their storage policies first.
-
-### What each agent stores, and how it is managed
-
-| Agent | State | Managed as |
-|---|---|---|
-| Claude Code | `~/.claude/settings.json` | **symlink** → `configs/claude/settings.json` |
-| Claude Code | `~/.claude/hooks/*.sh` | **symlink** → `agent-skills/hooks/` |
-| Claude Code | `~/.claude/skills/skill-index` | **symlink** → `configs/claude/skill-index` |
-| Claude Code | `~/.claude/skills/<category>/<name>` | symlinks rebuilt from `configs/claude/skills.manifest` (public skills only; private ones are restored from their own repo) |
-| Claude Code | `~/.claude/projects/<slug>/memory` | **symlink** → `configs/claude/memory` |
-| Claude Code | MCP servers | `claude mcp add` (idempotent, run by the module) |
-| Codex | `~/.codex/config.toml` | **merge** — managed plugins/MCP/hooks + local trust, notify and UI state |
-| Codex | `~/.local/bin/codex-workspace-trust-sync` | symlink/copy from this repo; regenerates exact-path project trust |
-| Both | statusline | `cship` module (binaries + `~/.config/{cship,starship}.toml` symlinks) |
-
-**Why Claude Code is symlinked but Codex is not.** Claude Code never rewrites
-`settings.json` — a full session and the `/config` UI both left the symlink and
-its target untouched, so the repo copy can be the real file. Codex writes into
-its config continuously: 137 project-trust entries and 18 hook trust hashes on
-this machine. Symlinking it would drag that churn into git, so
-`scripts/codex/apply-config.sh` layers the managed half over whatever the local
-machine already has instead.
-
-`configs/claude/settings.json` uses `$HOME/...` rather than absolute paths.
-Hook commands and `statusLine.command` are run through a shell, so the expansion
-happens at run time and the file works under any username. Codex does **not**
-expand `$HOME` in TOML values, which is why its per-machine paths are excluded
-from the template rather than rewritten.
-
-### Symlink or copy
-
-Symlink is the default and the reason drift cannot happen: `~/.claude/settings.json`
-*is* `configs/claude/settings.json`, so editing one edits the other. The cost is
-that the live config depends on the repo staying checked out at a branch that
-contains it.
-
-`--copy` installs real files and directories instead, including all 46 nested
-skills, for machines where that dependency is unwanted:
+## After installing
 
 ```bash
-./install.sh -c claude cship        # copy instead of symlink
+exec zsh                           # or: source ~/.zshrc
+eza --version && rg --version      # sanity check
 ```
 
-Copy mode is idempotent — a second run compares contents and reports
-"already up to date" rather than re-copying. The trade-off is that local edits
-no longer flow back, so after changing a copied config you have to bring it
-into the repo by hand.
+The aliases come from `configs/.zshrc`: `ls`/`ll`/`la`/`lt` → eza, `find` → fd,
+`grep` → rg, `du` → dust, `ps` → procs, `top`/`htop` → btm, `vim`/`vi` → nvim, and
+`zs`/`za`/`zl` for zellij sessions. The PowerShell profile mirrors these, except that
+the ones shadowing an existing command stay interactive-only — see
+[windows.md](docs/windows.md#powershell).
 
-The self-extracting release bundle always forces copy mode because its temporary
-extraction directory is removed as soon as installation finishes.
+## Repo layout
 
-No template engine sits in between: after excluding per-machine runtime state,
-zero managed values need substitution. `configs/claude/settings.json` and both
-cship configs contain no absolute paths at all, and Codex's template contains
-none either now that project trust, hook hashes and the version-pinned
-`[[skills.config]]` path are captured out.
-
-### Keeping the repo in sync
-
-```bash
-# after changing Codex settings by hand or through its UI
-./scripts/codex/capture-config.sh && git diff configs/codex
-
-# after adding or removing a nested Claude skill
-python3 ~/.claude/skills/skill-index/build.py
-./scripts/claude/capture-skills.sh && git diff configs/claude
-```
-
-Claude Code needs nothing — `~/.claude/settings.json` *is* the repo file.
-
-### Deliberately not managed
-
-| | Why |
-|---|---|
-| `~/.envs/*.env` | Secrets. Restore by hand; `~/.agents/*.md` documents which key each integration needs. |
-| `agents/{static,<workspace>/static}` personal files | Profile, endpoints and service-specific context. They are gitignored; restore from a secure backup or fill the generated samples. |
-| `~/.claude.json` | MCP registrations sit next to per-project state Claude Code rewrites constantly. The `claude` module re-adds servers instead. |
-| `~/.claude/.credentials.json`, `~/.codex/auth.json` | OAuth tokens. Re-login on the new machine. |
-| `~/.config/muxa/config.toml` | Carries a dashboard auth token; restore it privately after installing muxa. |
-| Codex `notify` | Absolute, machine-local Oh My Prompt hook path. Create it with `omp install --cli codex`; later applies preserve it. |
-| Codex project trust | Exact-path and per-machine; regenerate with the repo-installed `codex-workspace-trust-sync`. |
-
-## Directory Structure
-
-```
+```text
 settings/
-├── install.sh              # Main entry point
-├── bootstrap.sh            # Remote installation bootstrap
-├── lib/                    # Core libraries
-│   ├── core.sh            #   Logging, spinner, utilities
-│   ├── platform.sh        #   Platform detection, package manager
-│   └── cli.sh             #   CLI argument parsing
-├── modules/                # Installation modules
-│   ├── base.sh            #   Basic packages
-│   ├── shell.sh           #   Zsh + zinit + P10k
-│   ├── editor.sh          #   NeoVim + LazyVim
-│   ├── tmux.sh            #   tmux + TPM
-│   ├── zellij.sh          #   zellij
-│   ├── rust.sh            #   Rust + cargo-binstall
-│   ├── python.sh          #   uv
-│   ├── tools.sh           #   CLI tools
-│   ├── ssh.sh             #   SSH config
-│   ├── hishtory.sh        #   hishtory + self-hosted sync
-│   ├── hammerspoon.sh     #   Hammerspoon (macOS-only)
-│   ├── codex.sh           #   Codex CLI/App config
-│   ├── claude.sh          #   Claude Code settings, skills and memory
-│   ├── cship.sh           #   cship + Starship statusline
-│   └── scripts.sh         #   Personal CLI scripts → ~/.local/bin
-├── bin/                    # Personal CLI scripts (linked onto PATH)
-│   └── subd               #   Run a command across subdirectories
-├── worker/                 # Cloudflare Worker — written, never deployed (see below)
-│   ├── index.js           #   Proxy raw GitHub content
-│   └── wrangler.toml      #   Wrangler configuration
-├── scripts/                # Build scripts
-│   ├── bundle.sh          #   Create bundled installer
-│   ├── claude/            #   Skill-farm capture helper
-│   ├── codex/             #   Config capture/apply + trust sync
-│   └── wsl2-network.ps1   #   WSL2 network setup script
-├── configs/                # Configuration files
-│   ├── .zshrc
-│   ├── .p10k.zsh
-│   ├── .tmux.conf         #   tmux configuration
-│   ├── .rmux.conf         #   rmux configuration (Windows)
-│   ├── powershell/         #   PowerShell profile + starship prompt (Windows)
-│   ├── zellij/            #   zellij config + layouts
-│   ├── nvim/              #   NeoVim + LazyVim config
-│   ├── hishtory/          #   hishtory config template
-│   ├── codex/             #   Codex managed config template
-│   ├── claude/            #   Claude settings, manifest, index and memory
-│   ├── cship/             #   cship + Starship configs
-│   └── windows-terminal/  #   Windows Terminal configuration
-└── .github/workflows/      # CI/CD
-    └── release.yml         #   Auto-release on tag
+├── install.sh              # Main installer
+├── bootstrap.sh            # One-line installer (also published to gh-pages)
+├── lib/                    # Shared: cli, core, platform
+├── modules/                # One file per component
+├── configs/                # The dotfiles themselves
+│   ├── .zshrc .p10k.zsh .tmux.conf .rmux.conf
+│   ├── nvim/ zellij/ powershell/ windows-terminal/
+│   └── claude/ codex/ cship/ hishtory/
+├── bin/                    # Personal CLI scripts, linked onto PATH
+├── scripts/                # Build and maintenance helpers
+├── docs/                   # The guides linked below
+└── worker/                 # Cloudflare Worker — written, never deployed
 ```
 
-## How settings.jiun.dev is served
+## Documentation
 
-**GitHub Pages, from the `gh-pages` branch** — not the Cloudflare Worker in `worker/`.
-That Worker was written but never deployed; the live responses carry
-`x-github-request-id` and Fastly's `via: 1.1 varnish`, and none of the `x-repo` header
-`worker/index.js` sets on every 200. `gh api repos/jiunbae/settings/pages` confirms
-`source: { branch: gh-pages, path: / }`. Cloudflare only proxies the domain.
+| | |
+| :--- | :--- |
+| [windows.md](docs/windows.md) | rmux, PowerShell, NeoVim, Windows Terminal, Nextcloud upload |
+| [powershell.md](docs/powershell.md) | How the PowerShell profile went from 1354ms to 394ms |
+| [agent-state.md](docs/agent-state.md) | Restoring Claude Code / Codex state on a new machine |
+| [tmux-to-zellij.md](docs/tmux-to-zellij.md) | Migration notes |
 
-`gh-pages` holds three files: `CNAME`, `bootstrap.sh`, and `index.html` — where
-`index.html` is a byte-identical copy of `bootstrap.sh`, which is what makes
-`curl -LsSf https://settings.jiun.dev | bash` work with no path.
+## Maintaining this repo
+
+`settings.jiun.dev` is **GitHub Pages from the `gh-pages` branch**, not the Worker in
+`worker/` — that was written but never deployed. `gh-pages` carries its own copy of
+`bootstrap.sh`, duplicated as `index.html` so the pathless one-liner works, and nothing
+syncs it automatically.
 
 > [!IMPORTANT]
-> `bootstrap.sh` therefore exists **twice**: the real one here on the default branch,
-> and the copy on `gh-pages` that is actually served. Nothing syncs them — no workflow
-> in `.gitea/`, `.github/` or `scripts/` references `gh-pages`. The copy went stale for
-> over five months once (live: 2026-02-22, repo: 2026-07-31), which meant the live
-> installer was missing the guard that refuses to `git reset --hard` over uncommitted
-> local changes. **After changing `bootstrap.sh`, copy it to both `bootstrap.sh` and
-> `index.html` on `gh-pages`.**
-
-## Platform Support
-
-| Platform | Package Manager | Architecture |
-|----------|-----------------|--------------|
-| Ubuntu/Debian | apt | x86_64, arm64 |
-| macOS | Homebrew | Intel, Apple Silicon |
-| WSL | apt | x86_64 |
-
-## Examples
-
-```bash
-# Preview installation (dry-run)
-./install.sh --dry-run --all
-
-# Install shell environment only
-./install.sh zsh
-
-# Install with verbose output
-./install.sh -v zsh nvim tmux
-
-# Force reinstall everything
-./install.sh --force --all
-
-# Install Rust and CLI tools
-./install.sh rust tools tools-extra
-```
-
-## Post-Installation
-
-```bash
-# Restart your shell
-source ~/.zshrc
-# or
-exec zsh
-
-# Verify installations
-eza --version
-fd --version
-bat --version
-rg --version
-```
-
-## Shell Aliases
-
-After installation, these aliases are configured in `.zshrc`:
-
-```bash
-# Modern replacements
-alias ls='eza --icons'
-alias ll='eza -la --icons --git'
-alias cat='bat'
-alias find='fd'
-alias grep='rg'
-alias du='dust'
-alias ps='procs'
-alias top='btm'
-
-# Zellij (terminal multiplexer)
-alias zs='zellij -s'        # new session
-alias za='zellij attach'    # attach
-alias zl='zellij list-sessions'  # list
-
-
-# Editor
-alias vim='nvim'
-alias vi='nvim'
-```
-
-## Windows Terminal Configuration
-
-Configuration for Windows Terminal is available in `configs/windows-terminal/settings.json`.
-
-### How to apply
-
-1. Open Windows Terminal
-2. Press `Ctrl + ,` to open Settings
-3. Click **Open JSON file** at the bottom of the left sidebar
-4. Copy the contents of `configs/windows-terminal/settings.json` and paste them into your `settings.json`
-
-> [!TIP]
-> This configuration uses **JetBrainsMonoNL Nerd Font**. Make sure it's installed on your Windows system for the best experience.
-
-## RMUX Configuration (Windows)
-
-[rmux](https://github.com/Helvesec/rmux) is a tmux-compatible multiplexer that runs
-natively on Windows, where `install.sh` cannot go — `lib/platform.sh` only detects
-Linux and Darwin. `configs/.rmux.conf` is the subset of `configs/.tmux.conf` that
-works there: mouse, copy-mode, splits, `hjkl` navigation/resize and the Korean
-two-set prefix mappings. Plugins (TPM, catppuccin), the `uname`-based `if-shell`
-blocks and the muxa popups are omitted.
-
-### How to apply
-
-1. `winget install rmux`
-2. Copy `configs/.rmux.conf` to `%USERPROFILE%\.rmux.conf`
-3. Start a session: `rmux new-session -A -s main`
-
-rmux reads `%XDG_CONFIG_HOME%\rmux\rmux.conf`, `%USERPROFILE%\.rmux.conf`,
-`%APPDATA%\rmux\rmux.conf` and `%RMUX_CONFIG_FILE%`. With none of them present it
-falls back to parsing a `tmux.conf`, but only from the standard paths — a bare
-Windows box has no `~/.tmux.conf`, so nothing is loaded and every option stays at
-its default.
-
-> [!TIP]
-> `mouse` is **off** by default in rmux, so wheel scrolling and the scrollback are
-> unreachable until `set-option -g mouse on` is loaded — the most common symptom of
-> a missing config. To check a running server: `rmux show-options -g mouse`.
-> `prefix + R` reloads `~/.rmux.conf`.
-
-## PowerShell Configuration (Windows)
-
-`configs/powershell/profile.ps1` is `.zshrc` ported to PowerShell 7, for the same
-reason as `.rmux.conf`: `install.sh` cannot run on Windows. `configs/powershell/starship.toml`
-is the prompt that replaces Powerlevel10k, laid out to match the p10k config in
-`configs/.p10k.zsh`.
-
-There is no zinit equivalent and none is needed — PSReadLine 2.4 ships prediction
-and syntax highlighting natively, which is what `zsh-autosuggestions` and
-`fast-syntax-highlighting` were loaded for. The history options, the whole `bindkey`
-block, `AUTO_PUSHD`/`cd -`, the `$+commands` tool aliases, `mkcd`, the agent
-wrappers and the Korean two-set prefix policy all carry over.
-
-### How to apply
-
-1. Install the tools:
-   ```powershell
-   winget install --id Starship.Starship --id eza-community.eza --id sharkdp.fd `
-     --id BurntSushi.ripgrep.MSVC --id sharkdp.bat --id dandavison.delta `
-     --id bootandy.dust --id dalance.procs --id Clement.bottom --id junegunn.fzf `
-     --id ajeetdsouza.zoxide --id Neovim.Neovim --id Schniz.fnm --id jqlang.jq
-   Install-Module PSFzf -Scope CurrentUser
-   ```
-2. Point `$PROFILE` at the repo copy — Windows symlinks need elevation or Developer
-   Mode, so dot-source instead of linking:
-   ```powershell
-   @'
-   $repoProfile = "$env:USERPROFILE\workspace\settings\configs\powershell\profile.ps1"
-   if (Test-Path $repoProfile) { . $repoProfile }
-   '@ | Set-Content $PROFILE
-   ```
-3. Put machine-local additions in `profile.local.ps1` next to `$PROFILE`. The repo
-   profile sources it last, the same way `.zshrc` sources `~/.zshrc.local` — this
-   repo is public.
-
-### What does not port
-
-| `.zshrc` | Why |
-| :--- | :--- |
-| p10k instant prompt | No equivalent; starship renders in ~20ms unprimed |
-| `hishtory` | Supports bash/zsh/fish only, so history is PSReadLine-local |
-| `umask 077` | Windows uses ACLs |
-| `GPG_TTY` / `updatestartuptty` | pinentry-qt draws a GUI dialog |
-| `AUTO_CD` | Needs `CommandNotFoundAction`, already claimed by PowerToys. `zoxide`'s `z` covers the same ground |
-| `SHARE_HISTORY` | `SaveIncrementally` appends as you go, but no live in-session sharing |
-| nvm lazy-load shims | `fnm --use-on-cd` is already lazy |
-| `arch -arch` aliases | macOS only |
-
-### Startup cost
-
-A profile runs on every shell, so it is measured rather than guessed. Medians of 9
-interleaved runs of `pwsh -NoProfile -Command "… ; . profile.ps1"` against a 171ms
-bare-shell baseline, on a 42-entry PATH:
-
-| | Scripted shell | Profile's own cost |
-| :--- | ---: | ---: |
-| First working version | 1354 ms | 1183 ms |
-| `Test-Tool` instead of `Get-Command` | 783 ms | 613 ms |
-| After the rest of the passes below | **405 ms** | **222 ms** |
-
-~123ms of what remains is engine warm-up, not profile work.
-
-The techniques, in order of what they were worth:
-
-- **Never `Get-Command` a tool that might be absent.** A miss walks every PATH
-  directory against every `PATHEXT` — ~720ms for the first one. `Test-Tool` reads a
-  dictionary built from a single pass over PATH. Restricting that pass to
-  `*.exe,*.com,*.cmd,*.bat,*.ps1` cut it from 13,688 files (~200ms) to 993 (~66ms).
-- **Guard everything interactive on `$script:Interactive`.** This is the faithful
-  port, not just an optimization: `.zshrc` is only sourced by interactive zsh in the
-  first place. It skips PSReadLine, starship (~160ms) and the uv completion (~67ms,
-  736KB of generated script) in a scripted shell. Decide it from pwsh's own argv
-  (`-Command`, `-File`, `-NonInteractive`), **not** from `[Console]::IsOutputRedirected`
-  — Windows OpenSSH gives a child process pipes instead of a console, so the stream
-  test calls an interactive ssh session scripted and throws the prompt away.
-- **Refresh PATH from the registry first.** A process inherits the PATH that existed
-  when it was created, so a tool installed into the Machine PATH afterwards (winget
-  does this for starship, bottom and Neovim) is invisible to every shell descended
-  from an older session — over ssh, opening a "new terminal" just forks the same
-  stale `cmd.exe`. Without this the tool probe reports the tool absent and the prompt
-  quietly never loads. ~32ms, appended so deliberate process additions still win.
-- **Shadowing aliases are interactive-only; additive ones are not.** `ps` as procs
-  prints text where `Get-Process` returns objects, and `find`/`grep` as fd/rg take
-  different flags, so those belong behind the same guard on correctness grounds.
-  `ll`, `la`, `lt`, `vim`, `z` and the agent wrappers introduce new names that cannot
-  collide, so they stay available in scripts and agent shells.
-- **Cache shell-init output.** `starship`, `zoxide`, `fnm` and `uv` print the same
-  script on every launch. `Import-CachedInit` caches to `$env:TEMP`, invalidated on
-  the tool's own mtime. `starship init powershell` is worth special mention: all it
-  emits is a line that runs starship *again* with `--print-full-init`, so the
-  uncached path spawned it twice.
-- **`[System.IO.*]` instead of `Test-Path` / `Get-Content`.** Not for the I/O — for
-  the cmdlet. The first cmdlet invocation in a fresh pwsh costs ~123ms of engine
-  warm-up no matter which one it is (one cmdlet 123ms, two 124ms, none 2ms), so it
-  is only worth paying where a cmdlet is actually needed.
-- **Defer PSFzf to its first keypress.** Importing it costs ~396ms for three key
-  handlers. Stubs on Ctrl+T / Ctrl+R / Alt+C import on demand and then re-point
-  themselves at PSFzf's exported `Invoke-FzfPsReadlineHandler*` functions.
-
-> [!TIP]
-> `Measure-Script` from [PSProfiler](https://github.com/IISResetMe/PSProfiler) gives
-> per-line costs, and inserting `[Stopwatch]` marks at each section header gives
-> per-section ones. Both were needed here: the line-level view found the PATH scan,
-> the section view found that starship was still spawning a second process.
-
-## NeoVim Configuration (Windows)
-
-`configs/nvim/` needs no Windows variant — nothing in it is POSIX-specific. What it
-needs is to be *found*: NeoVim reads `%LOCALAPPDATA%\nvim` on Windows, so installing
-the binary alone (`winget install Neovim.Neovim`) leaves a stock editor with no
-plugins and no keymaps, which looks like a working install until you notice `vim` has
-none of your bindings.
-
-### How to apply
-
-```powershell
-winget install --id Neovim.Neovim
-npm install -g tree-sitter-cli          # nvim-treesitter compiles parsers with it
-New-Item -ItemType Junction -Path "$env:LOCALAPPDATA\nvim" `
-         -Target "$env:USERPROFILE\workspace\settings\configs\nvim"
-nvim --headless "+Lazy! install" +qa
-nvim --headless "+Lazy! restore" +qa
-```
-
-A **junction**, not a symlink: a directory junction needs no elevation and no
-Developer Mode, where `New-Item -ItemType SymbolicLink` needs one of them. It is the
-closest equivalent to the symlink `modules/editor.sh` makes at `~/.config/nvim`, and
-it keeps `lazy-lock.json` writable in place, so a plugin update on Windows shows up
-as a repo change exactly as it does on macOS and Linux.
-
-`Lazy! restore` after `Lazy! install` is what pins the 35 plugins to the commits in
-`lazy-lock.json` rather than to whatever is newest that day, so this machine matches
-the others.
-
-There is no winget package for the tree-sitter CLI; npm ships a prebuilt binary,
-where `cargo install tree-sitter-cli` would compile it. Without it `mason.nvim`
-reports `Failed to install tree-sitter-cli` and `nvim-treesitter` cannot build
-parsers.
-
-> [!WARNING]
-> `lazy-lock.json` is a tracked file reached through the junction, so lazy.nvim writes
-> into the repo. If lazy ever dies while writing it, the file is left truncated to
-> `{` — check `git status` in this repo after a plugin operation, and
-> `git restore configs/nvim/lazy-lock.json` if it looks short. A line-ending-only diff
-> is normal and expected: lazy writes LF, `core.autocrlf` checks out CRLF.
-
-### Repairing an existing lazy.nvim install
-
-The bootstrap in `lua/config/lazy.lua` runs only when `lazypath` does not exist, so
-fixing it does **not** heal a machine where lazy.nvim was already installed with a
-detached HEAD. Such an install keeps truncating `lazy-lock.json` on every `Lazy!`
-command. Check and repair:
-
-```sh
-cd "${XDG_DATA_HOME:-$HOME/.local/share}/nvim/lazy/lazy.nvim"   # Windows: %LOCALAPPDATA%\nvim-data\lazy\lazy.nvim
-git rev-parse --abbrev-ref HEAD     # "HEAD" means detached — needs repairing
-git checkout -B main HEAD           # same commit, now on a branch
-```
-
-To find out whether a machine is affected at all, ask lazy.nvim which plugin it cannot
-name a branch for:
-
-```sh
-nvim --headless -c 'lua local G=require("lazy.manage.git") for _,p in pairs(require("lazy.core.config").plugins) do if p._.installed and not p._.is_local then local i=G.info(p.dir) if not i or not (i.branch or G.get_branch(p)) then print("no branch: "..p.name) end end end' -c 'qa!'
-```
-
-> [!NOTE]
-> LazyVim needs NeoVim 0.11 or newer (`modules/editor.sh` pins 0.11.2). Check with
-> `nvim --version`; a `nvim --version` that works proves only that the editor is
-> installed, not that this config is loaded. To check that, run
-> `nvim --headless -c 'lua print(pcall(require, "lazyvim"))' -c 'qa!'`.
-
-## Troubleshooting
-
-**View installation log:**
-```bash
-cat ~/.install.log
-```
-
-**Force reinstall a component:**
-```bash
-./install.sh --force zsh
-```
-
-**Run in verbose mode:**
-```bash
-./install.sh --verbose --all
-```
+> After changing `bootstrap.sh`, run `scripts/sync-gh-pages.sh --push`. The copy once
+> went stale for five months — long enough that the published installer was missing the
+> guard that refuses to `git reset --hard` over uncommitted local changes.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -68,14 +68,15 @@ git clone https://github.com/jiunbae/settings.git && cd settings
 | **Shell** | [zsh](https://www.zsh.org/) + [zinit](https://github.com/zdharma-continuum/zinit) + [Powerlevel10k](https://github.com/romkatv/powerlevel10k), with [autosuggestions](https://github.com/zsh-users/zsh-autosuggestions) and [fast-syntax-highlighting](https://github.com/z-shell/fast-syntax-highlighting) · PowerShell 7 + [starship](https://starship.rs/) + [PSFzf](https://github.com/kelleyma49/PSFzf) on Windows |
 | **Editor** | [NeoVim](https://neovim.io/) + [LazyVim](https://www.lazyvim.org/), with the [tree-sitter CLI](https://github.com/tree-sitter/tree-sitter) for parsers |
 | **Multiplexer** | [tmux](https://github.com/tmux/tmux) + [TPM](https://github.com/tmux-plugins/tpm) · [zellij](https://zellij.dev/) · [rmux](https://github.com/Helvesec/rmux) on Windows |
-| **CLI tools** | [eza](https://github.com/eza-community/eza) `ls` · [fd](https://github.com/sharkdp/fd) `find` · [bat](https://github.com/sharkdp/bat) `cat` · [ripgrep](https://github.com/BurntSushi/ripgrep) `grep` · [fzf](https://github.com/junegunn/fzf) |
+| **CLI tools** | [eza](https://github.com/eza-community/eza) `ls` · [fd](https://github.com/sharkdp/fd) `find` · [ripgrep](https://github.com/BurntSushi/ripgrep) `grep` · [fzf](https://github.com/junegunn/fzf) |
 | **CLI extras** | [delta](https://github.com/dandavison/delta) `git diff` · [dust](https://github.com/bootandy/dust) `du` · [procs](https://github.com/dalance/procs) `ps` · [bottom](https://github.com/ClementTsang/bottom) `htop` |
 | **Toolchains** | [Rust](https://www.rust-lang.org/) + [cargo-binstall](https://github.com/cargo-bins/cargo-binstall) · [uv](https://github.com/astral-sh/uv) · [fnm](https://github.com/Schniz/fnm) |
 | **AI agents** | Claude Code · Codex · [cship](https://github.com/stephenleo/cship) statusline — see [agent-state.md](docs/agent-state.md) |
 | **History** | [hishtory](https://github.com/ddworken/hishtory) — context, search, cross-device sync |
 | **macOS** | [Hammerspoon](https://www.hammerspoon.org/) — window, screen and keyboard automation |
 
-Every component is independent, safe to re-run, and has a `--dry-run`.
+Components install independently and are safe to re-run; `--dry-run` previews any
+combination of them without changing anything.
 
 ## Platform Support
 
@@ -105,9 +106,10 @@ Options:
   -c, --copy          Copy config files instead of symlink
   -l, --link          Create symlinks for config files (default)
   -v, --verbose       Enable verbose output
-  -n, --dry-run       Show what would be done
+  -n, --dry-run       Show what would be done without making changes
   --no-sudo           Skip commands that require sudo privileges
-  -h, --help          Show help message
+  -h, --help          Show this help message
+  --version           Show version
 
 Components:
   base          Basic packages (curl, wget, git, build-essential)
@@ -117,14 +119,15 @@ Components:
   zellij        zellij (modern terminal multiplexer)
   rust          Rust toolchain + cargo-binstall
   uv            uv (fast Python package manager)
-  tools         CLI tools (eza, fd, bat, ripgrep, fzf)
+  tools         CLI tools (eza, fd, ripgrep, fzf)
   tools-extra   Extra CLI tools (delta, dust, procs, bottom)
   ssh           SSH config (copy only, not symlinked)
-  hishtory      hishtory (better shell history with sync support)
+  hishtory      hishtory (better shell history with self-hosted sync)
   hammerspoon   Hammerspoon (macOS-only: window manager + keybindings)
+  ghostty       Ghostty terminal config (macOS-only: Option-as-Alt so TUI Alt bindings work)
   codex         Codex CLI/App config, hooks, and notify chain
-  claude        Claude Code settings, hooks, skill index, memory, MCP
-  cship         cship + Starship (fast Claude Code statusline)
+  claude        Claude Code settings, hooks, skill index, memory, MCP servers
+  cship         cship + Starship (fast Claude Code statusline, replaces ccstatusline)
   scripts       Personal CLI scripts linked into ~/.local/bin
 ```
 

--- a/bin/windows/Setup-Nextcloud.ps1
+++ b/bin/windows/Setup-Nextcloud.ps1
@@ -1,0 +1,158 @@
+<#
+  Nextcloud 업로드 환경 설정 (cloud-upload CLI + rclone + 네트워크 드라이브)
+  실행:  pwsh -ExecutionPolicy Bypass -File .\Setup-Nextcloud.ps1
+  관리자 권한으로 실행하면 네트워크 드라이브 50MB 제한 해제까지 처리합니다.
+#>
+param(
+  # 기본값 없음(이 레포는 public). 생략하면 기존 설정에서 읽거나 물어봅니다.
+  [string]$Server      = "",
+  [string]$RemoteDir   = "Uploads",
+  [string]$DriveLetter = "Z",
+  # /Uploads 를 캐시로 쓰기 위해 .nomedia 를 넣어 Photos/Memories/previewgenerator 에서 제외
+  [bool]$NoMedia       = $true
+)
+
+$ErrorActionPreference = "Stop"
+function Info($m) { Write-Host "  $m" -ForegroundColor Cyan }
+function Ok($m)   { Write-Host "  OK   $m" -ForegroundColor Green }
+function Warn($m) { Write-Host "  SKIP $m" -ForegroundColor Yellow }
+
+# 서버 주소 확정: 인자 > 기존 .cloud-upload.json > 직접 입력
+if (-not $Server) {
+  $prev = Join-Path $env:USERPROFILE ".cloud-upload.json"
+  if (Test-Path $prev) { $Server = (Get-Content $prev -Raw | ConvertFrom-Json).server }
+}
+if (-not $Server) { $Server = Read-Host "Nextcloud 서버 주소 (예: https://cloud.example.com)" }
+$Server = $Server.TrimEnd('/')
+
+$hostName = ([uri]$Server).Host
+Write-Host "`n=== Nextcloud 업로드 설정 ($hostName) ===`n" -ForegroundColor White
+
+# -- 1. 자격 증명 입력 --------------------------------------------------
+$user = Read-Host "Nextcloud 사용자 ID"
+$sec  = Read-Host "앱 비밀번호 (입력이 화면에 안 보입니다)" -AsSecureString
+$pass = [Runtime.InteropServices.Marshal]::PtrToStringAuto(
+          [Runtime.InteropServices.Marshal]::SecureStringToBSTR($sec))
+
+$dav = "$Server/remote.php/dav/files/$user/"
+
+# -- 2. 인증 확인 -------------------------------------------------------
+Info "인증 확인 중..."
+$code = & curl.exe -s -o NUL -w "%{http_code}" -u "${user}:${pass}" `
+          -X PROPFIND -H "Depth: 0" $dav
+if ($code -ne "207") {
+  Write-Host "  FAIL 인증 실패 (HTTP $code). 사용자 ID / 앱 비밀번호를 확인하세요." -ForegroundColor Red
+  Write-Host "       앱 비밀번호 발급: $Server/settings/user/security" -ForegroundColor Red
+  exit 1
+}
+Ok "인증 성공 -> $dav"
+
+# -- 3. curl 용 _netrc (비밀번호를 명령어/기록에 안 남기기 위함) ---------
+$netrc = Join-Path $env:USERPROFILE "_netrc"
+$line  = "machine $hostName login $user password $pass"
+if (Test-Path $netrc) {
+  $kept = Get-Content $netrc | Where-Object { $_ -notmatch "^machine\s+$([regex]::Escape($hostName))\s" }
+  Set-Content $netrc (@($kept) + $line) -Encoding ascii
+} else {
+  Set-Content $netrc $line -Encoding ascii
+}
+Ok "_netrc 작성 -> $netrc"
+
+# -- 4. cloud-upload 설정 파일 (ID를 매번 안 치기 위함) -------------------
+$cfg = Join-Path $env:USERPROFILE ".cloud-upload.json"
+[pscustomobject]@{ server = $Server; user = $user; remoteDir = $RemoteDir } |
+  ConvertTo-Json | Set-Content $cfg -Encoding utf8
+Ok "설정 저장 -> $cfg"
+
+# -- 5. 원격 폴더 + .nomedia -------------------------------------------
+& curl.exe -s -o NUL -u "${user}:${pass}" -X MKCOL "$dav$RemoteDir"
+Ok "원격 폴더 준비 -> /$RemoteDir"
+
+if ($NoMedia) {
+  $tmp = New-TemporaryFile
+  & curl.exe -s -o NUL -u "${user}:${pass}" -T $tmp.FullName "$dav$RemoteDir/.nomedia"
+  Remove-Item $tmp -Force
+  Ok ".nomedia 업로드 -> /$RemoteDir (Photos/Memories/previewgenerator 제외)"
+}
+
+# -- 6. cloud-upload 설치 (%USERPROFILE%\bin, PATH 등록) ----------------
+$bin = Join-Path $env:USERPROFILE "bin"
+New-Item -ItemType Directory -Force $bin | Out-Null
+
+# settings 레포의 사본을 그대로 쓴다. 복사하면 두 벌이 갈라지므로
+# $PROFILE 과 같은 방식으로 "가리키기"만 한다 (Windows 심볼릭 링크는 권한 필요).
+$src = Join-Path $PSScriptRoot "cloud-upload.ps1"
+if (Test-Path $src) {
+  Remove-Item (Join-Path $bin "cloud-upload.ps1") -Force -ErrorAction SilentlyContinue
+  @"
+@echo off
+pwsh -NoProfile -ExecutionPolicy Bypass -File "$src" %*
+"@ | Set-Content (Join-Path $bin "cloud-upload.cmd") -Encoding oem
+
+  $userPath = [Environment]::GetEnvironmentVariable("Path", "User")
+  if ($userPath -notlike "*$bin*") {
+    [Environment]::SetEnvironmentVariable("Path", "$userPath;$bin", "User")
+  }
+  $env:PATH += ";$bin"
+  Ok "cloud-upload 설치 -> $bin\cloud-upload.cmd  ->  $src"
+} else {
+  Warn "cloud-upload.ps1 을 찾을 수 없음 ($src)"
+}
+
+# -- 7. rclone 설치 + 원격 등록 -----------------------------------------
+$env:PATH += ";$env:LOCALAPPDATA\Microsoft\WinGet\Links"
+if (-not (Get-Command rclone -ErrorAction SilentlyContinue)) {
+  Info "rclone 설치 중 (winget)..."
+  winget install -e --id Rclone.Rclone --accept-package-agreements --accept-source-agreements | Out-Null
+  $env:PATH += ";$env:LOCALAPPDATA\Microsoft\WinGet\Links"
+}
+if (Get-Command rclone -ErrorAction SilentlyContinue) {
+  rclone config delete nc 2>$null | Out-Null
+  rclone config create nc webdav url=$dav vendor=nextcloud user=$user pass=$pass --obscure | Out-Null
+  Ok "rclone 원격 'nc' 등록   (rclone sync C:\upload nc:$RemoteDir -P)"
+} else {
+  Warn "rclone 설치 실패 - 수동 설치 필요"
+}
+
+# -- 8. WebClient 서비스 + 파일 크기 제한 해제 ---------------------------
+$admin = ([Security.Principal.WindowsPrincipal] `
+          [Security.Principal.WindowsIdentity]::GetCurrent()
+         ).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+if ($admin) {
+  Set-Service WebClient -StartupType Automatic
+  $reg = "HKLM:\SYSTEM\CurrentControlSet\Services\WebClient\Parameters"
+  Set-ItemProperty $reg FileSizeLimitInBytes 0xFFFFFFFF -Type DWord
+  Set-ItemProperty $reg BasicAuthLevel       2          -Type DWord
+  Restart-Service WebClient -Force
+  Ok "WebClient 자동시작 + 파일 크기 제한 해제 (50MB -> 4GB)"
+} else {
+  Warn "관리자 아님 - 50MB 제한이 남습니다. 관리자 PowerShell에서 재실행하세요."
+  if ((Get-Service WebClient).Status -ne "Running") { Start-Service WebClient }
+}
+
+# -- 9. 네트워크 드라이브 매핑 ------------------------------------------
+& net use "${DriveLetter}:" /delete /y 2>$null | Out-Null
+& net use "${DriveLetter}:" $dav /user:$user $pass /persistent:yes | Out-Null
+if (Test-Path "${DriveLetter}:\") {
+  Ok "네트워크 드라이브 매핑 -> ${DriveLetter}:  (탐색기에서 드래그앤드롭)"
+} else {
+  Warn "드라이브 매핑 실패 - WebClient 서비스 상태를 확인하세요."
+}
+
+# -- 10. 우클릭 '보내기' 메뉴 -------------------------------------------
+$sendTo = Join-Path $env:APPDATA "Microsoft\Windows\SendTo\Nextcloud 업로드.cmd"
+@"
+@echo off
+chcp 65001 >nul
+pwsh -NoProfile -ExecutionPolicy Bypass -File "$src" %*
+echo.
+pause
+"@ | Set-Content $sendTo -Encoding oem
+Ok "우클릭 -> 보내기 -> 'Nextcloud 업로드' 등록"
+
+Write-Host "`n=== 완료 ===`n" -ForegroundColor White
+Write-Host "  cloud-upload `"C:\경로\파일.zip`""
+Write-Host "  cloud-upload C:\logs\*.log -To logs"
+Write-Host "  cloud-upload C:\build\dist -Share -Expire 7"
+Write-Host "  탐색기: ${DriveLetter}: 드라이브 / 우클릭 -> 보내기`n"
+Write-Host "  (PATH가 갱신되었으니 새 터미널을 여세요)`n" -ForegroundColor Yellow

--- a/bin/windows/cloud-upload.ps1
+++ b/bin/windows/cloud-upload.ps1
@@ -1,0 +1,414 @@
+<#
+.SYNOPSIS
+  Nextcloud로 파일/폴더를 업로드합니다. 이미 올라간 파일은 건너뜁니다.
+
+.EXAMPLE
+  cloud-upload report.pdf
+  cloud-upload C:\logs\*.zip
+  cloud-upload C:\build\dist -To builds        # 폴더 재귀 업로드 (변경분만)
+  cloud-upload C:\build\dist -DryRun           # 무엇이 올라갈지만 확인
+  cloud-upload C:\build\dist -Force            # 스킵 없이 전부 재업로드
+  cloud-upload big.iso -Share -Expire 7        # 공개 링크를 클립보드로
+
+  자격 증명은 %USERPROFILE%\_netrc, 대상 정보는
+  %USERPROFILE%\.cloud-upload.json 에서 읽습니다 (Setup-Nextcloud.ps1이 생성).
+
+.NOTES
+  중복 업로드 회피 (2026-09 실측, Nextcloud 32.0.3)
+    - PROPFIND Depth:infinity 1회로 원격 트리 전체를 받아온다 (200개/62KB = 0.16s).
+      Nextcloud가 거부하면(403) 디렉터리별 Depth:1 재귀로 자동 폴백.
+    - 비교는 "크기 + mtime". 해시 비교는 불가능하다:
+        · d:getetag 는 내용 해시가 아니라 서버 내부 값 (재현 불가)
+        · oc:checksum 은 OC-Checksum 헤더를 보내도 저장되지 않음 (검증 완료)
+        · 진짜 해시를 얻으려면 원격 파일을 내려받아야 하는데, 그건 재업로드보다 느리다
+    - 업로드 시 X-OC-Mtime 헤더로 로컬 mtime을 그대로 심는다. 덕분에 다음 실행에서
+      mtime이 정확히 일치하고 스킵 판정이 확실해진다.
+    - 기존에 올라간(= mtime이 업로드 시각인) 파일은 "크기 같음 + 원격이 더 최신"이면
+      스킵한다. 업로드 전용 워크플로에서는 안전한 규칙. 엄격히 하려면 -Strict.
+
+  전송 방식
+    - 기본(curl)  : 50MB 단일 80 MB/s   <- 가장 빠름
+    - -Sync(rclone): 50MB 단일 24 MB/s
+    이제 기본 경로도 변경분만 올리므로 -Sync 는 거의 필요 없다.
+#>
+[CmdletBinding()]
+param(
+  [Parameter(Position = 0, ValueFromRemainingArguments = $true)]
+  [string[]]$Path,
+
+  # 원격 하위 폴더 (기본: 설정의 remoteDir)
+  [string]$To,
+
+  # 변경된 파일만 전송 (rclone). 하위 호환용
+  [switch]$Sync,
+
+  # 업로드 후 공개 공유 링크 생성 + 클립보드 복사
+  [switch]$Share,
+
+  # 링크 만료일 (예: -Expire 7). -Share 와 함께 사용
+  [int]$Expire = 0,
+
+  # 병렬 전송 수
+  [int]$Transfers = 8,
+
+  # 스킵 판정 없이 전부 업로드
+  [switch]$Force,
+
+  # mtime 이 정확히 일치할 때만 스킵 (기본: 원격이 더 최신이어도 스킵)
+  [switch]$Strict,
+
+  # 실제로 올리지 않고 계획만 출력
+  [switch]$DryRun
+)
+
+$ErrorActionPreference = "Stop"
+function Die($m) { Write-Host "cloud-upload: $m" -ForegroundColor Red; exit 1 }
+
+# ---- 설정 로드 --------------------------------------------------------
+$cfgPath = Join-Path $env:USERPROFILE ".cloud-upload.json"
+if (-not (Test-Path $cfgPath)) { Die "설정 없음 ($cfgPath). Setup-Nextcloud.ps1 를 먼저 실행하세요." }
+$cfg = Get-Content $cfgPath -Raw | ConvertFrom-Json
+
+$server = $cfg.server.TrimEnd('/')
+$user   = $cfg.user
+$root   = if ($To) { $To.Trim('/') } else { $cfg.remoteDir.Trim('/') }
+$dav    = "$server/remote.php/dav/files/$user"
+$davPath = ([uri]$dav).AbsolutePath.TrimEnd('/')    # /remote.php/dav/files/<user>
+
+# Schannel 빌드(System32)가 HTTP/1.1 이지만 실측상 가장 빠름. HTTP/2 빌드는 오히려 느림.
+$curl = "$env:WINDIR\System32\curl.exe"
+if (-not (Test-Path $curl)) { $curl = (Get-Command curl.exe -ErrorAction Stop).Source }
+
+if (-not $Path -or $Path.Count -eq 0) {
+  Write-Host "사용법: cloud-upload <파일|폴더|와일드카드> [-To 하위폴더] [-Force] [-Strict] [-DryRun] [-Share] [-Expire 일수] [-Transfers N] [-Sync]"
+  Write-Host "대상  : $server/  ->  /$root   (사용자: $user)"
+  Write-Host "curl  : $curl"
+  exit 0
+}
+
+function Enc([string]$s) { [uri]::EscapeDataString($s) }
+function Remote-Url([string]$relative) {
+  $parts = @($relative.Trim('/') -split '/' | Where-Object { $_ -ne '' })
+  return "$dav/" + (($parts | ForEach-Object { Enc $_ }) -join '/')
+}
+
+$uploaded = [Collections.Generic.List[string]]::new()
+$skipped  = [Collections.Generic.List[string]]::new()
+$failed   = [Collections.Generic.List[string]]::new()
+$sw       = [Diagnostics.Stopwatch]::StartNew()
+$totalSize = 0
+
+# ---- 원격 인덱스 ------------------------------------------------------
+# 반환: @{ Files = @{rel -> @{Size; Mtime(UTC)}}; Dirs = HashSet<rel>; Ok = bool }
+$PROPFIND_BODY = '<?xml version="1.0"?><d:propfind xmlns:d="DAV:"><d:prop><d:getcontentlength/><d:getlastmodified/><d:resourcetype/></d:prop></d:propfind>'
+
+function Parse-Multistatus($xmlText, $files, $dirs) {
+  $xml = [xml]$xmlText
+  $ns = [System.Xml.XmlNamespaceManager]::new($xml.NameTable)
+  $ns.AddNamespace('d', 'DAV:')
+  foreach ($resp in $xml.SelectNodes('//d:response', $ns)) {
+    $href = $resp.SelectSingleNode('d:href', $ns).InnerText
+    # href 는 절대경로 또는 절대 URL. 퍼센트 인코딩되어 있다.
+    if ($href -match '^https?://') { $href = ([uri]$href).AbsolutePath }
+    $href = [uri]::UnescapeDataString($href)
+    if (-not $href.StartsWith($davPath, [StringComparison]::OrdinalIgnoreCase)) { continue }
+    $rel = $href.Substring($davPath.Length).Trim('/')
+    if ($rel -eq '') { continue }
+
+    $ok = $resp.SelectSingleNode("d:propstat[starts-with(d:status,'HTTP/1.1 200')]/d:prop", $ns)
+    if (-not $ok) { continue }
+    if ($ok.SelectSingleNode('d:resourcetype/d:collection', $ns)) {
+      [void]$dirs.Add($rel)
+      continue
+    }
+    $lenNode = $ok.SelectSingleNode('d:getcontentlength', $ns)
+    $modNode = $ok.SelectSingleNode('d:getlastmodified', $ns)
+    if (-not $lenNode) { continue }
+    $mt = [DateTime]::MinValue
+    if ($modNode -and $modNode.InnerText) {
+      try {
+        $mt = [DateTime]::Parse($modNode.InnerText, [Globalization.CultureInfo]::InvariantCulture,
+              [Globalization.DateTimeStyles]::AdjustToUniversal -bor [Globalization.DateTimeStyles]::AssumeUniversal)
+      } catch { }
+    }
+    $files[$rel] = @{ Size = [int64]$lenNode.InnerText; Mtime = $mt }
+  }
+}
+
+function Get-RemoteIndex([string]$rootRel) {
+  $files = @{}
+  $dirs  = [Collections.Generic.HashSet[string]]::new([StringComparer]::Ordinal)
+  $body  = New-TemporaryFile
+  Set-Content $body.FullName $PROPFIND_BODY -Encoding utf8 -NoNewline
+
+  try {
+    $out = & $curl -s -n -X PROPFIND -H "Depth: infinity" -H "Content-Type: application/xml" `
+                   --data-binary "@$($body.FullName)" -w "`n%{http_code}" (Remote-Url $rootRel) 2>$null
+    $text = ($out | Out-String)
+    $code = ($text.TrimEnd() -split "`n")[-1].Trim()
+    $xmlText = $text.Substring(0, [Math]::Max(0, $text.TrimEnd().Length - $code.Length))
+
+    if ($code -eq '207') {
+      Parse-Multistatus $xmlText $files $dirs
+      return @{ Files = $files; Dirs = $dirs; Ok = $true }
+    }
+    if ($code -eq '404') {
+      # 대상 폴더가 아직 없음 -> 전부 신규
+      return @{ Files = $files; Dirs = $dirs; Ok = $true }
+    }
+
+    # Depth:infinity 거부(보통 403) -> 디렉터리별 Depth:1 BFS 폴백
+    Write-Host "  (Depth:infinity 거부됨 [$code], 디렉터리별 조회로 폴백)" -ForegroundColor DarkYellow
+    $queue = [Collections.Generic.Queue[string]]::new()
+    $queue.Enqueue($rootRel)
+    $seen = [Collections.Generic.HashSet[string]]::new([StringComparer]::Ordinal)
+    while ($queue.Count -gt 0) {
+      $cur = $queue.Dequeue()
+      if (-not $seen.Add($cur)) { continue }
+      $before = [Collections.Generic.HashSet[string]]::new($dirs, [StringComparer]::Ordinal)
+      $o = & $curl -s -n -X PROPFIND -H "Depth: 1" -H "Content-Type: application/xml" `
+                   --data-binary "@$($body.FullName)" (Remote-Url $cur) 2>$null
+      $t = ($o | Out-String)
+      if ($t -notmatch 'multistatus') { continue }
+      Parse-Multistatus $t $files $dirs
+      foreach ($d in $dirs) { if (-not $before.Contains($d) -and $d -ne $cur) { $queue.Enqueue($d) } }
+    }
+    return @{ Files = $files; Dirs = $dirs; Ok = $true }
+  } catch {
+    Write-Host "  (원격 목록 조회 실패: $_ - 전부 업로드합니다)" -ForegroundColor DarkYellow
+    return @{ Files = @{}; Dirs = $dirs; Ok = $false }
+  } finally {
+    Remove-Item $body -Force -ErrorAction SilentlyContinue
+  }
+}
+
+# ---- -Sync: rclone 에 위임 --------------------------------------------
+if ($Sync) {
+  $rclone = Get-Command rclone -ErrorAction SilentlyContinue
+  if (-not $rclone) { Die "-Sync 에는 rclone 이 필요합니다. winget install Rclone.Rclone" }
+  if ((& rclone listremotes 2>$null) -notcontains "nc:") { Die "rclone 원격 'nc' 가 없습니다. Setup-Nextcloud.ps1 재실행." }
+
+  foreach ($p in $Path) {
+    foreach ($it in @(Resolve-Path -Path $p -ErrorAction SilentlyContinue)) {
+      $fs = Get-Item -LiteralPath $it.Path
+      $dst = if ($fs.PSIsContainer) { "nc:$root/$($fs.Name)" } else { "nc:$root" }
+      $src = if ($fs.PSIsContainer) { $fs.FullName } else { $fs.DirectoryName }
+      Write-Host "[sync] $($fs.FullName)  ->  /$($dst.Substring(3))" -ForegroundColor Cyan
+      if ($fs.PSIsContainer) {
+        & rclone copy $src $dst --transfers $Transfers --checkers $Transfers --progress --stats-one-line --stats 1s
+      } else {
+        & rclone copy $src $dst --include $fs.Name --transfers $Transfers --progress --stats-one-line --stats 1s
+      }
+      if ($LASTEXITCODE -ne 0) { $failed.Add($fs.Name) } else { $uploaded.Add($fs.Name) }
+    }
+  }
+}
+else {
+  # ---- 대상 수집 (폴더는 재귀 전개) -----------------------------------
+  $jobs = [Collections.Generic.List[object]]::new()
+  foreach ($p in $Path) {
+    $items = @(Resolve-Path -Path $p -ErrorAction SilentlyContinue)
+    if ($items.Count -eq 0) { Die "경로를 찾을 수 없음: $p" }
+    foreach ($it in $items) {
+      $fs = Get-Item -LiteralPath $it.Path
+      if ($fs.PSIsContainer) {
+        foreach ($f in Get-ChildItem -LiteralPath $fs.FullName -File -Recurse) {
+          $sub = $f.FullName.Substring($fs.FullName.Length).TrimStart('\') -replace '\\', '/'
+          $jobs.Add(@{ Local = $f.FullName; Rel = "$root/$($fs.Name)/$sub"; Info = $f })
+        }
+      } else {
+        $jobs.Add(@{ Local = $fs.FullName; Rel = "$root/$($fs.Name)"; Info = $fs })
+      }
+    }
+  }
+  if ($jobs.Count -eq 0) { Die "업로드할 파일이 없습니다." }
+
+  # ---- 원격과 비교해서 스킵 -------------------------------------------
+  $index = @{ Files = @{}; Dirs = [Collections.Generic.HashSet[string]]::new([StringComparer]::Ordinal) }
+  if (-not $Force) {
+    $isw = [Diagnostics.Stopwatch]::StartNew()
+    $index = Get-RemoteIndex $root
+    $isw.Stop()
+    Write-Host ("[인덱스] 원격 {0}개 파일 / {1}개 폴더 ({2:N2}s)" -f $index.Files.Count, $index.Dirs.Count, $isw.Elapsed.TotalSeconds) -ForegroundColor DarkGray
+
+    $todo = [Collections.Generic.List[object]]::new()
+    foreach ($j in $jobs) {
+      $r = $index.Files[$j.Rel]
+      if ($r -and $r.Size -eq $j.Info.Length) {
+        $lm = $j.Info.LastWriteTimeUtc
+        $delta = ($r.Mtime - $lm).TotalSeconds
+        # 정확히 일치(±2s, exFAT/네트워크 드라이브 오차) 또는 (비엄격) 원격이 더 최신
+        if ([Math]::Abs($delta) -le 2 -or (-not $Strict -and $delta -gt 0)) {
+          $skipped.Add($j.Rel); continue
+        }
+      }
+      $todo.Add($j)
+    }
+    $jobs = $todo
+  }
+
+  if ($skipped.Count -gt 0) {
+    Write-Host "[스킵] 이미 동일한 파일 $($skipped.Count)개" -ForegroundColor DarkGray
+  }
+  if ($jobs.Count -eq 0) {
+    $sw.Stop()
+    Write-Host ("최신 상태입니다. 전송할 것 없음 ({0:N2}s)" -f $sw.Elapsed.TotalSeconds) -ForegroundColor Green
+    exit 0
+  }
+
+  foreach ($j in $jobs) { $totalSize += $j.Info.Length }
+
+  if ($DryRun) {
+    Write-Host "[DryRun] 업로드 예정 $($jobs.Count)개, $("{0:N1}" -f ($totalSize/1MB)) MB" -ForegroundColor Yellow
+    $jobs | ForEach-Object { Write-Host "  + $($_.Rel)" -ForegroundColor Yellow }
+    exit 0
+  }
+
+  # ---- 없는 폴더만 MKCOL (한 번의 curl 로 일괄) -----------------------
+  $needDirs = [Collections.Generic.HashSet[string]]::new([StringComparer]::Ordinal)
+  foreach ($j in $jobs) {
+    $acc = @()
+    foreach ($seg in (((Split-Path $j.Rel -Parent) -replace '\\', '/').Trim('/') -split '/')) {
+      if ($seg -eq '') { continue }
+      $acc += $seg
+      $sub = $acc -join '/'
+      if (-not $index.Dirs.Contains($sub)) { [void]$needDirs.Add($sub) }
+    }
+  }
+  if ($needDirs.Count -gt 0) {
+    # 부모 먼저 생성해야 하므로 깊이 순으로 정렬, 병렬 금지.
+    # @() 필수: Sort-Object 는 원소가 하나면 배열이 아니라 스칼라를 돌려주고,
+    # 그러면 $ordered[0] 이 문자열의 첫 "글자"가 된다 ("Uploads/output" -> "U").
+    $ordered = @($needDirs | Sort-Object { ($_ -split '/').Count }, { $_ })
+    $mk = New-TemporaryFile
+    $mb = [Text.StringBuilder]::new()
+    for ($i = 0; $i -lt $ordered.Count; $i++) {
+      [void]$mb.AppendLine("netrc")
+      [void]$mb.AppendLine("silent")
+      [void]$mb.AppendLine("output = `"NUL`"")
+      [void]$mb.AppendLine("write-out = `"%{http_code}\n`"")
+      [void]$mb.AppendLine("request = `"MKCOL`"")
+      [void]$mb.AppendLine("url = `"$(Remote-Url $ordered[$i])`"")
+      if ($i -lt $ordered.Count - 1) { [void]$mb.AppendLine("next") }
+    }
+    Set-Content $mk.FullName $mb.ToString() -Encoding utf8
+
+    # 201=생성, 405=이미 있음. 그 밖은 실패이고, 그대로 두면 뒤이은 PUT 이
+    # 영문 모를 404 로 죽는다 (부모 컬렉션이 없으면 WebDAV 는 404 를 준다).
+    $codes = @(& $curl -K $mk.FullName 2>$null)
+    Remove-Item $mk -Force -ErrorAction SilentlyContinue
+    $bad = @()
+    for ($i = 0; $i -lt $ordered.Count; $i++) {
+      $c = if ($i -lt $codes.Count) { "$($codes[$i])".Trim() } else { "응답 없음" }
+      if ($c -notmatch '^(201|405)$') { $bad += "$($ordered[$i])  (HTTP $c)" }
+    }
+    if ($bad.Count -gt 0) {
+      Write-Host "폴더 생성 실패 $($bad.Count)건:" -ForegroundColor Red
+      $bad | ForEach-Object { Write-Host "  - $_" -ForegroundColor Red }
+      Die "상위 폴더를 만들지 못해 중단합니다."
+    }
+    Write-Host "[폴더] $($needDirs.Count)개 생성" -ForegroundColor DarkGray
+  }
+
+  function Unix-Mtime($fi) { [int64]([DateTimeOffset]$fi.LastWriteTimeUtc).ToUnixTimeSeconds() }
+
+  if ($jobs.Count -le 4) {
+    # 적은 수 -> 진행률 바를 보여준다
+    $idx = 0
+    foreach ($j in $jobs) {
+      $idx++
+      $size = "{0:N1} MB" -f ($j.Info.Length / 1MB)
+      Write-Host ("[{0}/{1}] {2}  ({3})" -f $idx, $jobs.Count, $j.Rel, $size) -ForegroundColor Cyan
+      & $curl -n --fail --progress-bar -H "X-OC-Mtime: $(Unix-Mtime $j.Info)" -T $j.Local (Remote-Url $j.Rel)
+      if ($LASTEXITCODE -ne 0) { $failed.Add($j.Rel) } else { $uploaded.Add($j.Rel) }
+    }
+  }
+  else {
+    # 많은 수 -> 연결 재사용 + 병렬 전송
+    Write-Host "[전송] $($jobs.Count)개 파일, $("{0:N1}" -f ($totalSize/1MB)) MB (병렬 $Transfers)" -ForegroundColor Cyan
+    $conf = New-TemporaryFile
+    $byUrl = @{}
+    $sb = [Text.StringBuilder]::new()
+    for ($i = 0; $i -lt $jobs.Count; $i++) {
+      $local = $jobs[$i].Local -replace '\\', '/'   # curl 설정 파일에서 역슬래시는 이스케이프
+      $url   = Remote-Url $jobs[$i].Rel
+      $byUrl[$url] = $jobs[$i].Rel
+      [void]$sb.AppendLine("netrc")
+      [void]$sb.AppendLine("silent")
+      [void]$sb.AppendLine("show-error")
+      [void]$sb.AppendLine("write-out = `"%{http_code} %{url_effective}\n`"")
+      [void]$sb.AppendLine("header = `"X-OC-Mtime: $(Unix-Mtime $jobs[$i].Info)`"")
+      [void]$sb.AppendLine("upload-file = `"$local`"")
+      [void]$sb.AppendLine("url = `"$url`"")
+      if ($i -lt $jobs.Count - 1) { [void]$sb.AppendLine("next") }
+    }
+    Set-Content $conf.FullName $sb.ToString() -Encoding utf8
+
+    # -Z 는 완료 순서대로 출력하므로 URL 로 되짚는다 (인덱스 매칭 불가)
+    $done = [Collections.Generic.HashSet[string]]::new([StringComparer]::Ordinal)
+    $n = 0
+    & $curl -Z --parallel-max $Transfers -K $conf.FullName | ForEach-Object {
+      $parts = $_ -split '\s+', 2
+      if ($parts.Count -lt 2) { return }
+      $code = $parts[0]
+      $rel  = $byUrl[$parts[1].Trim()]
+      if (-not $rel) { $rel = $parts[1].Trim() }
+      [void]$done.Add($rel)
+      $n++
+      if ($code -match '^2\d\d$') {
+        $uploaded.Add($rel)
+        Write-Host ("  [{0}/{1}] {2}" -f $n, $jobs.Count, $rel) -ForegroundColor DarkGray
+      } else {
+        $failed.Add("$rel  (HTTP $code)")
+        Write-Host ("  [{0}/{1}] {2}  HTTP {3}" -f $n, $jobs.Count, $rel, $code) -ForegroundColor Red
+      }
+    }
+    Remove-Item $conf -Force -ErrorAction SilentlyContinue
+    foreach ($j in $jobs) { if (-not $done.Contains($j.Rel)) { $failed.Add("$($j.Rel)  (응답 없음)") } }
+  }
+}
+
+$sw.Stop()
+
+# ---- 결과 -------------------------------------------------------------
+Write-Host ""
+if ($failed.Count -gt 0) {
+  Write-Host "실패 $($failed.Count)건:" -ForegroundColor Red
+  $failed | ForEach-Object { Write-Host "  - $_" -ForegroundColor Red }
+}
+$secs = [Math]::Max($sw.Elapsed.TotalSeconds, 0.001)
+$rate = if ($totalSize -gt 0) { " / {0:N1} MB, {1:N1} MB/s" -f ($totalSize / 1MB), ($totalSize / 1MB / $secs) } else { "" }
+$skipMsg = if ($skipped.Count -gt 0) { ", 스킵 $($skipped.Count)건" } else { "" }
+Write-Host ("완료: {0}건{1}  ({2:N1}s{3})" -f $uploaded.Count, $skipMsg, $secs, $rate) -ForegroundColor Green
+
+# ---- 공개 링크 --------------------------------------------------------
+if ($Share -and ($uploaded.Count + $skipped.Count) -gt 0) {
+  $one = if ($uploaded.Count -eq 1 -and $skipped.Count -eq 0) { $uploaded[0] }
+         elseif ($uploaded.Count -eq 0 -and $skipped.Count -eq 1) { $skipped[0] }
+         else { $null }
+  $target = if ($one -and -not $Sync) { "/$one" } else { "/$root" }
+  $curlArgs = @(
+    "-s", "-n", "-H", "OCS-APIRequest: true",
+    "-X", "POST", "$server/ocs/v2.php/apps/files_sharing/api/v1/shares?format=json",
+    "--data-urlencode", "path=$target",
+    "--data-urlencode", "shareType=3",
+    "--data-urlencode", "permissions=1"
+  )
+  if ($Expire -gt 0) {
+    $curlArgs += @("--data-urlencode", "expireDate=$((Get-Date).AddDays($Expire).ToString('yyyy-MM-dd'))")
+  }
+  try {
+    $resp = (& $curl @curlArgs) | ConvertFrom-Json
+    $url = $resp.ocs.data.url
+    if ($url) {
+      Set-Clipboard -Value $url
+      Write-Host "공유 링크 (클립보드 복사됨): $url" -ForegroundColor Yellow
+    } else {
+      Write-Host "공유 링크 생성 실패: $($resp.ocs.meta.message)" -ForegroundColor Red
+    }
+  } catch {
+    Write-Host "공유 링크 생성 실패: $_" -ForegroundColor Red
+  }
+}
+
+if ($failed.Count -gt 0) { exit 1 }

--- a/bin/windows/cloud-upload.ps1
+++ b/bin/windows/cloud-upload.ps1
@@ -92,6 +92,20 @@ function Remote-Url([string]$relative) {
   return "$dav/" + (($parts | ForEach-Object { Enc $_ }) -join '/')
 }
 
+# Resolve once, before any transfer. A public link must name one explicit input,
+# never a common parent that may contain unrelated uploads.
+$inputs = @(
+  foreach ($p in $Path) {
+    $items = @(Resolve-Path -Path $p -ErrorAction SilentlyContinue)
+    if ($items.Count -eq 0) { Die "경로를 찾을 수 없음: $p" }
+    foreach ($it in $items) { Get-Item -LiteralPath $it.Path }
+  }
+)
+if ($Share -and $inputs.Count -ne 1) {
+  Die "-Share 는 파일 또는 폴더 하나만 지정하세요. 여러 경로는 각각 실행하세요."
+}
+$shareTarget = if ($Share) { "/$root/$($inputs[0].Name)" }
+
 $uploaded = [Collections.Generic.List[string]]::new()
 $skipped  = [Collections.Generic.List[string]]::new()
 $failed   = [Collections.Generic.List[string]]::new()
@@ -188,37 +202,31 @@ if ($Sync) {
   if (-not $rclone) { Die "-Sync 에는 rclone 이 필요합니다. winget install Rclone.Rclone" }
   if ((& rclone listremotes 2>$null) -notcontains "nc:") { Die "rclone 원격 'nc' 가 없습니다. Setup-Nextcloud.ps1 재실행." }
 
-  foreach ($p in $Path) {
-    foreach ($it in @(Resolve-Path -Path $p -ErrorAction SilentlyContinue)) {
-      $fs = Get-Item -LiteralPath $it.Path
-      $dst = if ($fs.PSIsContainer) { "nc:$root/$($fs.Name)" } else { "nc:$root" }
-      $src = if ($fs.PSIsContainer) { $fs.FullName } else { $fs.DirectoryName }
-      Write-Host "[sync] $($fs.FullName)  ->  /$($dst.Substring(3))" -ForegroundColor Cyan
-      if ($fs.PSIsContainer) {
-        & rclone copy $src $dst --transfers $Transfers --checkers $Transfers --progress --stats-one-line --stats 1s
-      } else {
-        & rclone copy $src $dst --include $fs.Name --transfers $Transfers --progress --stats-one-line --stats 1s
-      }
-      if ($LASTEXITCODE -ne 0) { $failed.Add($fs.Name) } else { $uploaded.Add($fs.Name) }
+  $copyOptions = @()
+  if ($DryRun) { $copyOptions += '--dry-run' }
+  foreach ($fs in $inputs) {
+    $dst = if ($fs.PSIsContainer) { "nc:$root/$($fs.Name)" } else { "nc:$root" }
+    $src = if ($fs.PSIsContainer) { $fs.FullName } else { $fs.DirectoryName }
+    Write-Host "[sync] $($fs.FullName)  ->  /$($dst.Substring(3))" -ForegroundColor Cyan
+    if ($fs.PSIsContainer) {
+      & rclone copy $src $dst --transfers $Transfers --checkers $Transfers --progress --stats-one-line --stats 1s @copyOptions
+    } else {
+      & rclone copy $src $dst --include $fs.Name --transfers $Transfers --progress --stats-one-line --stats 1s @copyOptions
     }
+    if ($LASTEXITCODE -ne 0) { $failed.Add($fs.Name) } else { $uploaded.Add($fs.Name) }
   }
 }
 else {
   # ---- 대상 수집 (폴더는 재귀 전개) -----------------------------------
   $jobs = [Collections.Generic.List[object]]::new()
-  foreach ($p in $Path) {
-    $items = @(Resolve-Path -Path $p -ErrorAction SilentlyContinue)
-    if ($items.Count -eq 0) { Die "경로를 찾을 수 없음: $p" }
-    foreach ($it in $items) {
-      $fs = Get-Item -LiteralPath $it.Path
-      if ($fs.PSIsContainer) {
-        foreach ($f in Get-ChildItem -LiteralPath $fs.FullName -File -Recurse) {
-          $sub = $f.FullName.Substring($fs.FullName.Length).TrimStart('\') -replace '\\', '/'
-          $jobs.Add(@{ Local = $f.FullName; Rel = "$root/$($fs.Name)/$sub"; Info = $f })
-        }
-      } else {
-        $jobs.Add(@{ Local = $fs.FullName; Rel = "$root/$($fs.Name)"; Info = $fs })
+  foreach ($fs in $inputs) {
+    if ($fs.PSIsContainer) {
+      foreach ($f in Get-ChildItem -LiteralPath $fs.FullName -File -Recurse) {
+        $sub = $f.FullName.Substring($fs.FullName.Length).TrimStart('\') -replace '\\', '/'
+        $jobs.Add(@{ Local = $f.FullName; Rel = "$root/$($fs.Name)/$sub"; Info = $f })
       }
+    } else {
+      $jobs.Add(@{ Local = $fs.FullName; Rel = "$root/$($fs.Name)"; Info = $fs })
     }
   }
   if ($jobs.Count -eq 0) { Die "업로드할 파일이 없습니다." }
@@ -253,7 +261,7 @@ else {
   if ($jobs.Count -eq 0) {
     $sw.Stop()
     Write-Host ("최신 상태입니다. 전송할 것 없음 ({0:N2}s)" -f $sw.Elapsed.TotalSeconds) -ForegroundColor Green
-    exit 0
+    if (-not $Share -or $DryRun) { exit 0 }
   }
 
   foreach ($j in $jobs) { $totalSize += $j.Info.Length }
@@ -382,15 +390,11 @@ $skipMsg = if ($skipped.Count -gt 0) { ", 스킵 $($skipped.Count)건" } else { 
 Write-Host ("완료: {0}건{1}  ({2:N1}s{3})" -f $uploaded.Count, $skipMsg, $secs, $rate) -ForegroundColor Green
 
 # ---- 공개 링크 --------------------------------------------------------
-if ($Share -and ($uploaded.Count + $skipped.Count) -gt 0) {
-  $one = if ($uploaded.Count -eq 1 -and $skipped.Count -eq 0) { $uploaded[0] }
-         elseif ($uploaded.Count -eq 0 -and $skipped.Count -eq 1) { $skipped[0] }
-         else { $null }
-  $target = if ($one -and -not $Sync) { "/$one" } else { "/$root" }
+if ($Share -and -not $DryRun -and $failed.Count -eq 0 -and ($uploaded.Count + $skipped.Count) -gt 0) {
   $curlArgs = @(
     "-s", "-n", "-H", "OCS-APIRequest: true",
     "-X", "POST", "$server/ocs/v2.php/apps/files_sharing/api/v1/shares?format=json",
-    "--data-urlencode", "path=$target",
+    "--data-urlencode", "path=$shareTarget",
     "--data-urlencode", "shareType=3",
     "--data-urlencode", "permissions=1"
   )

--- a/docs/agent-state.md
+++ b/docs/agent-state.md
@@ -1,0 +1,141 @@
+<!-- Moved out of README.md; linked from its Documentation section. -->
+
+# Restoring AI agent state on a new machine
+
+Claude Code and Codex keep their configuration in different shapes, so this repo
+manages them differently. Follow the order below — step 2 must happen before
+step 3, because `configs/claude/settings.json` references hook scripts that live
+in the agent-skills repo.
+
+```bash
+# 1. this repo
+git clone git@github.com:jiunbae/settings.git ~/personal/settings
+
+# 2. hook scripts referenced by Claude settings.json
+git clone git@github.com:jiunbae/agent-skills.git ~/personal/agent-skills
+
+# 3. shared skill/static-doc repo, then lay down ~/.agents/
+# private shared-skill repo — substitute your own remote
+git clone <private-agents-repo> ~/workspace/agents
+~/workspace/agents/scripts/install-static.sh
+~/workspace/agents/scripts/install-shims.sh
+
+# 4. external runtimes used by the managed hooks (examples)
+#    Install and log in to Claude Code and Codex through their official installers.
+brew install open330/tap/muxa             # or follow muxa's platform instructions
+npm install -g oh-my-prompt               # provides omp
+
+# 5. agents + statusline
+cd ~/personal/settings
+./install.sh claude cship codex
+
+# Restore Oh My Prompt's Codex notify entry after its own setup. Later Codex
+# config applies preserve this machine-local absolute command.
+omp install --cli codex
+
+# 6. private state — never in git
+#    - ~/.envs/*.env
+#    - ~/.config/muxa/config.toml
+#    - the gitignored personal files created from agents/*/*.sample.{md,yaml}
+#      (restore from a secure backup or replace every {{PLACEHOLDER}})
+#    - re-login instead of copying Claude/Codex credential files
+
+# 7. Codex directory trust is exact-path based and per-machine. The codex
+#    component installs this helper from scripts/codex/workspace-trust-sync.sh.
+~/.local/bin/codex-workspace-trust-sync
+```
+
+The three Git clones restore versioned configuration and scripts. They cannot
+restore credentials, dashboard tokens, or the personalized `agents/static` and
+`agents/<workspace>/static` files because those are deliberately gitignored. A
+matching file count under `~/.agents` is therefore only a topology check; verify
+the contents and resolve the install-static placeholder warning before use.
+
+> [!WARNING]
+> These are personal settings for trusted workspaces. The managed Codex config
+> uses `approval_policy = "never"` with `sandbox_mode = "danger-full-access"`,
+> and Claude settings skip the dangerous-mode confirmation. Do not install them
+> unchanged on an untrusted repository or shared machine. The configured muxa,
+> Oh My Prompt, and prompt-logger hooks also receive agent lifecycle events or
+> prompt content; review those local tools and their storage policies first.
+
+## What each agent stores, and how it is managed
+
+| Agent | State | Managed as |
+|---|---|---|
+| Claude Code | `~/.claude/settings.json` | **symlink** → `configs/claude/settings.json` |
+| Claude Code | `~/.claude/hooks/*.sh` | **symlink** → `agent-skills/hooks/` |
+| Claude Code | `~/.claude/skills/skill-index` | **symlink** → `configs/claude/skill-index` |
+| Claude Code | `~/.claude/skills/<category>/<name>` | symlinks rebuilt from `configs/claude/skills.manifest` (public skills only; private ones are restored from their own repo) |
+| Claude Code | `~/.claude/projects/<slug>/memory` | **symlink** → `configs/claude/memory` |
+| Claude Code | MCP servers | `claude mcp add` (idempotent, run by the module) |
+| Codex | `~/.codex/config.toml` | **merge** — managed plugins/MCP/hooks + local trust, notify and UI state |
+| Codex | `~/.local/bin/codex-workspace-trust-sync` | symlink/copy from this repo; regenerates exact-path project trust |
+| Both | statusline | `cship` module (binaries + `~/.config/{cship,starship}.toml` symlinks) |
+
+**Why Claude Code is symlinked but Codex is not.** Claude Code never rewrites
+`settings.json` — a full session and the `/config` UI both left the symlink and
+its target untouched, so the repo copy can be the real file. Codex writes into
+its config continuously: 137 project-trust entries and 18 hook trust hashes on
+this machine. Symlinking it would drag that churn into git, so
+`scripts/codex/apply-config.sh` layers the managed half over whatever the local
+machine already has instead.
+
+`configs/claude/settings.json` uses `$HOME/...` rather than absolute paths.
+Hook commands and `statusLine.command` are run through a shell, so the expansion
+happens at run time and the file works under any username. Codex does **not**
+expand `$HOME` in TOML values, which is why its per-machine paths are excluded
+from the template rather than rewritten.
+
+## Symlink or copy
+
+Symlink is the default and the reason drift cannot happen: `~/.claude/settings.json`
+*is* `configs/claude/settings.json`, so editing one edits the other. The cost is
+that the live config depends on the repo staying checked out at a branch that
+contains it.
+
+`--copy` installs real files and directories instead, including all 46 nested
+skills, for machines where that dependency is unwanted:
+
+```bash
+./install.sh -c claude cship        # copy instead of symlink
+```
+
+Copy mode is idempotent — a second run compares contents and reports
+"already up to date" rather than re-copying. The trade-off is that local edits
+no longer flow back, so after changing a copied config you have to bring it
+into the repo by hand.
+
+The self-extracting release bundle always forces copy mode because its temporary
+extraction directory is removed as soon as installation finishes.
+
+No template engine sits in between: after excluding per-machine runtime state,
+zero managed values need substitution. `configs/claude/settings.json` and both
+cship configs contain no absolute paths at all, and Codex's template contains
+none either now that project trust, hook hashes and the version-pinned
+`[[skills.config]]` path are captured out.
+
+## Keeping the repo in sync
+
+```bash
+# after changing Codex settings by hand or through its UI
+./scripts/codex/capture-config.sh && git diff configs/codex
+
+# after adding or removing a nested Claude skill
+python3 ~/.claude/skills/skill-index/build.py
+./scripts/claude/capture-skills.sh && git diff configs/claude
+```
+
+Claude Code needs nothing — `~/.claude/settings.json` *is* the repo file.
+
+## Deliberately not managed
+
+| | Why |
+|---|---|
+| `~/.envs/*.env` | Secrets. Restore by hand; `~/.agents/*.md` documents which key each integration needs. |
+| `agents/{static,<workspace>/static}` personal files | Profile, endpoints and service-specific context. They are gitignored; restore from a secure backup or fill the generated samples. |
+| `~/.claude.json` | MCP registrations sit next to per-project state Claude Code rewrites constantly. The `claude` module re-adds servers instead. |
+| `~/.claude/.credentials.json`, `~/.codex/auth.json` | OAuth tokens. Re-login on the new machine. |
+| `~/.config/muxa/config.toml` | Carries a dashboard auth token; restore it privately after installing muxa. |
+| Codex `notify` | Absolute, machine-local Oh My Prompt hook path. Create it with `omp install --cli codex`; later applies preserve it. |
+| Codex project trust | Exact-path and per-machine; regenerate with the repo-installed `codex-workspace-trust-sync`. |

--- a/docs/components.md
+++ b/docs/components.md
@@ -2,7 +2,8 @@
 
 Per-component setup that does not belong on the landing page: the parts that need a
 decision, a secret, or a manual permission grant. Everything here was in the README
-before it was split; the text is unchanged.
+before it was split. Three single-row tables that had lost their headers are prose now;
+the rest is unchanged.
 
 | | |
 | :--- | :--- |

--- a/docs/components.md
+++ b/docs/components.md
@@ -1,0 +1,55 @@
+# Component notes
+
+Per-component setup that does not belong on the landing page: the parts that need a
+decision, a secret, or a manual permission grant. Everything here was in the README
+before it was split; the text is unchanged.
+
+| | |
+| :--- | :--- |
+| [hishtory](#hishtory) | Shell history with cross-device sync |
+| [Hammerspoon](#hammerspoon) | macOS automation, needs an Accessibility grant |
+| [Codex](#codex) | What the managed config does and does not touch |
+
+## hishtory
+
+[hishtory](https://github.com/ddworken/hishtory) gives shell history context, search and
+cross-machine sync.
+
+**hishtory features:**
+- Context-aware history (directory, exit code, duration)
+- Fuzzy search with `Ctrl+R`
+- E2E encrypted sync across machines
+- Self-hosted server support
+
+**Configuration (`~/.envs/hishtory.env`):**
+```bash
+# Self-hosted server (optional, local-only mode without this)
+export HISHTORY_SERVER="https://hishtory.example.com"
+
+# Secret key for cross-device sync (get from `hishtory status`)
+export HISHTORY_SECRET="your-secret-key-uuid"
+```
+
+Without `HISHTORY_SERVER`, hishtory runs in local-only mode.
+To sync across devices, use the same `HISHTORY_SECRET` on all machines.
+
+## Hammerspoon
+
+[Hammerspoon](https://www.hammerspoon.org/) is Lua-scriptable macOS automation for
+windows, screens and the keyboard.
+
+**Installs via Homebrew Cask and symlinks `~/.hammerspoon/init.lua` to this repo.**
+Skipped automatically on Linux/WSL. Accessibility permission must be granted manually:
+System Settings → Privacy & Security → Accessibility → enable Hammerspoon.
+
+## Codex
+
+The `codex` component applies a managed half of `config.toml` over whatever is
+already there:
+
+It applies stable model, plugin, MCP and hook settings, disables the legacy
+`~/.codex/hooks.json`, and preserves machine-local runtime sections — project and hook
+trust, `notify`, TUI state, desktop settings.
+
+Restoring Codex and Claude Code state on a new machine — including what is
+deliberately left unmanaged — is in [agent-state.md](agent-state.md).

--- a/docs/powershell.md
+++ b/docs/powershell.md
@@ -1,0 +1,60 @@
+# PowerShell profile performance
+
+How `configs/powershell/profile.ps1` got from 1354ms to 394ms, and why each step was
+worth it. Setup instructions are in [windows.md](windows.md#powershell).
+
+
+A profile runs on every shell, so it is measured rather than guessed. Medians of 9
+interleaved runs of `pwsh -NoProfile -Command "… ; . profile.ps1"` against a 171ms
+bare-shell baseline, on a 42-entry PATH:
+
+| | Scripted shell | Profile's own cost |
+| :--- | ---: | ---: |
+| First working version | 1354 ms | 1183 ms |
+| `Test-Tool` instead of `Get-Command` | 783 ms | 613 ms |
+| After the rest of the passes below | **405 ms** | **222 ms** |
+
+~123ms of what remains is engine warm-up, not profile work.
+
+The techniques, in order of what they were worth:
+
+- **Never `Get-Command` a tool that might be absent.** A miss walks every PATH
+  directory against every `PATHEXT` — ~720ms for the first one. `Test-Tool` reads a
+  dictionary built from a single pass over PATH. Restricting that pass to
+  `*.exe,*.com,*.cmd,*.bat,*.ps1` cut it from 13,688 files (~200ms) to 993 (~66ms).
+- **Guard everything interactive on `$script:Interactive`.** This is the faithful
+  port, not just an optimization: `.zshrc` is only sourced by interactive zsh in the
+  first place. It skips PSReadLine, starship (~160ms) and the uv completion (~67ms,
+  736KB of generated script) in a scripted shell. Decide it from pwsh's own argv
+  (`-Command`, `-File`, `-NonInteractive`), **not** from `[Console]::IsOutputRedirected`
+  — Windows OpenSSH gives a child process pipes instead of a console, so the stream
+  test calls an interactive ssh session scripted and throws the prompt away.
+- **Refresh PATH from the registry first.** A process inherits the PATH that existed
+  when it was created, so a tool installed into the Machine PATH afterwards (winget
+  does this for starship, bottom and Neovim) is invisible to every shell descended
+  from an older session — over ssh, opening a "new terminal" just forks the same
+  stale `cmd.exe`. Without this the tool probe reports the tool absent and the prompt
+  quietly never loads. ~32ms, appended so deliberate process additions still win.
+- **Shadowing aliases are interactive-only; additive ones are not.** `ps` as procs
+  prints text where `Get-Process` returns objects, and `find`/`grep` as fd/rg take
+  different flags, so those belong behind the same guard on correctness grounds.
+  `ll`, `la`, `lt`, `vim`, `z` and the agent wrappers introduce new names that cannot
+  collide, so they stay available in scripts and agent shells.
+- **Cache shell-init output.** `starship`, `zoxide`, `fnm` and `uv` print the same
+  script on every launch. `Import-CachedInit` caches to `$env:TEMP`, invalidated on
+  the tool's own mtime. `starship init powershell` is worth special mention: all it
+  emits is a line that runs starship *again* with `--print-full-init`, so the
+  uncached path spawned it twice.
+- **`[System.IO.*]` instead of `Test-Path` / `Get-Content`.** Not for the I/O — for
+  the cmdlet. The first cmdlet invocation in a fresh pwsh costs ~123ms of engine
+  warm-up no matter which one it is (one cmdlet 123ms, two 124ms, none 2ms), so it
+  is only worth paying where a cmdlet is actually needed.
+- **Defer PSFzf to its first keypress.** Importing it costs ~396ms for three key
+  handlers. Stubs on Ctrl+T / Ctrl+R / Alt+C import on demand and then re-point
+  themselves at PSFzf's exported `Invoke-FzfPsReadlineHandler*` functions.
+
+> [!TIP]
+> `Measure-Script` from [PSProfiler](https://github.com/IISResetMe/PSProfiler) gives
+> per-line costs, and inserting `[Stopwatch]` marks at each section header gives
+> per-section ones. Both were needed here: the line-level view found the PATH scan,
+> the section view found that starship was still spawning a second process.

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -232,3 +232,9 @@ is where the time goes.
 | `cloud-upload DIR -To sub` | Upload a folder, changed files only |
 | `cloud-upload DIR -DryRun` | List what would be uploaded |
 | `cloud-upload FILE -Share -Expire 7` | Public link to the clipboard, expiring in 7 days |
+
+`-Share` accepts exactly one file or folder (after wildcard expansion) and shares
+that item's remote path, including when its files are already uploaded. Multiple
+inputs are rejected before uploading; run each separately to create separate links.
+A folder link includes its existing remote contents. `-DryRun` also works with
+`-Sync` and never creates a public link.

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -1,0 +1,234 @@
+# Windows
+
+`install.sh` cannot run on Windows: `lib/platform.sh` `detect_platform` exits on
+anything that is not Linux or Darwin. So every Windows config here follows the same
+pattern instead — the file lives in `configs/`, and the steps below place it. Nothing
+is installed automatically.
+
+| | |
+| :--- | :--- |
+| [Windows Terminal](#windows-terminal) | `configs/windows-terminal/settings.json` |
+| [rmux](#rmux) | `configs/.rmux.conf` — tmux-compatible, native on Windows |
+| [PowerShell](#powershell) | `configs/powershell/` — `.zshrc` ported, starship prompt |
+| [NeoVim](#neovim) | `configs/nvim/` — same config as everywhere else |
+| [Nextcloud upload](#nextcloud-upload) | `bin/windows/cloud-upload.ps1` |
+
+## Windows Terminal
+
+Configuration for Windows Terminal is available in `configs/windows-terminal/settings.json`.
+
+### How to apply
+
+1. Open Windows Terminal
+2. Press `Ctrl + ,` to open Settings
+3. Click **Open JSON file** at the bottom of the left sidebar
+4. Copy the contents of `configs/windows-terminal/settings.json` and paste them into your `settings.json`
+
+> [!TIP]
+> This configuration uses **JetBrainsMonoNL Nerd Font**. Make sure it's installed on your Windows system for the best experience.
+
+
+## rmux
+
+[rmux](https://github.com/Helvesec/rmux) is a tmux-compatible multiplexer that runs
+natively on Windows, where `install.sh` cannot go — `lib/platform.sh` only detects
+Linux and Darwin. `configs/.rmux.conf` is the subset of `configs/.tmux.conf` that
+works there: mouse, copy-mode, splits, `hjkl` navigation/resize and the Korean
+two-set prefix mappings. Plugins (TPM, catppuccin), the `uname`-based `if-shell`
+blocks and the muxa popups are omitted.
+
+### How to apply
+
+1. `winget install rmux`
+2. Copy `configs/.rmux.conf` to `%USERPROFILE%\.rmux.conf`
+3. Start a session: `rmux new-session -A -s main`
+
+rmux reads `%XDG_CONFIG_HOME%\rmux\rmux.conf`, `%USERPROFILE%\.rmux.conf`,
+`%APPDATA%\rmux\rmux.conf` and `%RMUX_CONFIG_FILE%`. With none of them present it
+falls back to parsing a `tmux.conf`, but only from the standard paths — a bare
+Windows box has no `~/.tmux.conf`, so nothing is loaded and every option stays at
+its default.
+
+> [!TIP]
+> `mouse` is **off** by default in rmux, so wheel scrolling and the scrollback are
+> unreachable until `set-option -g mouse on` is loaded — the most common symptom of
+> a missing config. To check a running server: `rmux show-options -g mouse`.
+> `prefix + R` reloads `~/.rmux.conf`.
+
+
+## PowerShell
+
+`configs/powershell/profile.ps1` is `.zshrc` ported to PowerShell 7, for the same
+reason as `.rmux.conf`: `install.sh` cannot run on Windows. `configs/powershell/starship.toml`
+is the prompt that replaces Powerlevel10k, laid out to match the p10k config in
+`configs/.p10k.zsh`.
+
+There is no zinit equivalent and none is needed — PSReadLine 2.4 ships prediction
+and syntax highlighting natively, which is what `zsh-autosuggestions` and
+`fast-syntax-highlighting` were loaded for. The history options, the whole `bindkey`
+block, `AUTO_PUSHD`/`cd -`, the `$+commands` tool aliases, `mkcd`, the agent
+wrappers and the Korean two-set prefix policy all carry over.
+
+### How to apply
+
+1. Install the tools:
+   ```powershell
+   winget install --id Starship.Starship --id eza-community.eza --id sharkdp.fd `
+     --id BurntSushi.ripgrep.MSVC --id sharkdp.bat --id dandavison.delta `
+     --id bootandy.dust --id dalance.procs --id Clement.bottom --id junegunn.fzf `
+     --id ajeetdsouza.zoxide --id Neovim.Neovim --id Schniz.fnm --id jqlang.jq
+   Install-Module PSFzf -Scope CurrentUser
+   ```
+2. Point `$PROFILE` at the repo copy — Windows symlinks need elevation or Developer
+   Mode, so dot-source instead of linking:
+   ```powershell
+   @'
+   $repoProfile = "$env:USERPROFILE\workspace\settings\configs\powershell\profile.ps1"
+   if (Test-Path $repoProfile) { . $repoProfile }
+   '@ | Set-Content $PROFILE
+   ```
+3. Put machine-local additions in `profile.local.ps1` next to `$PROFILE`. The repo
+   profile sources it last, the same way `.zshrc` sources `~/.zshrc.local` — this
+   repo is public.
+
+### What does not port
+
+| `.zshrc` | Why |
+| :--- | :--- |
+| p10k instant prompt | No equivalent; starship renders in ~20ms unprimed |
+| `hishtory` | Supports bash/zsh/fish only, so history is PSReadLine-local |
+| `umask 077` | Windows uses ACLs |
+| `GPG_TTY` / `updatestartuptty` | pinentry-qt draws a GUI dialog |
+| `AUTO_CD` | Needs `CommandNotFoundAction`, already claimed by PowerToys. `zoxide`'s `z` covers the same ground |
+| `SHARE_HISTORY` | `SaveIncrementally` appends as you go, but no live in-session sharing |
+| nvm lazy-load shims | `fnm --use-on-cd` is already lazy |
+| `arch -arch` aliases | macOS only |
+
+
+> [!NOTE]
+> The profile is measured, not guessed: its own cost is 222ms against a 171ms
+> bare-shell baseline, down from 1183ms. The techniques and the numbers are in
+> [powershell.md](powershell.md).
+
+## NeoVim
+
+`configs/nvim/` needs no Windows variant — nothing in it is POSIX-specific. What it
+needs is to be *found*: NeoVim reads `%LOCALAPPDATA%\nvim` on Windows, so installing
+the binary alone (`winget install Neovim.Neovim`) leaves a stock editor with no
+plugins and no keymaps, which looks like a working install until you notice `vim` has
+none of your bindings.
+
+### How to apply
+
+```powershell
+winget install --id Neovim.Neovim
+npm install -g tree-sitter-cli          # nvim-treesitter compiles parsers with it
+New-Item -ItemType Junction -Path "$env:LOCALAPPDATA\nvim" `
+         -Target "$env:USERPROFILE\workspace\settings\configs\nvim"
+nvim --headless "+Lazy! install" +qa
+nvim --headless "+Lazy! restore" +qa
+```
+
+A **junction**, not a symlink: a directory junction needs no elevation and no
+Developer Mode, where `New-Item -ItemType SymbolicLink` needs one of them. It is the
+closest equivalent to the symlink `modules/editor.sh` makes at `~/.config/nvim`, and
+it keeps `lazy-lock.json` writable in place, so a plugin update on Windows shows up
+as a repo change exactly as it does on macOS and Linux.
+
+`Lazy! restore` after `Lazy! install` is what pins the 35 plugins to the commits in
+`lazy-lock.json` rather than to whatever is newest that day, so this machine matches
+the others.
+
+There is no winget package for the tree-sitter CLI; npm ships a prebuilt binary,
+where `cargo install tree-sitter-cli` would compile it. Without it `mason.nvim`
+reports `Failed to install tree-sitter-cli` and `nvim-treesitter` cannot build
+parsers.
+
+> [!WARNING]
+> `lazy-lock.json` is a tracked file reached through the junction, so lazy.nvim writes
+> into the repo. If lazy ever dies while writing it, the file is left truncated to
+> `{` — check `git status` in this repo after a plugin operation, and
+> `git restore configs/nvim/lazy-lock.json` if it looks short. A line-ending-only diff
+> is normal and expected: lazy writes LF, `core.autocrlf` checks out CRLF.
+
+### Repairing an existing lazy.nvim install
+
+The bootstrap in `lua/config/lazy.lua` runs only when `lazypath` does not exist, so
+fixing it does **not** heal a machine where lazy.nvim was already installed with a
+detached HEAD. Such an install keeps truncating `lazy-lock.json` on every `Lazy!`
+command. Check and repair:
+
+```sh
+cd "${XDG_DATA_HOME:-$HOME/.local/share}/nvim/lazy/lazy.nvim"   # Windows: %LOCALAPPDATA%\nvim-data\lazy\lazy.nvim
+git rev-parse --abbrev-ref HEAD     # "HEAD" means detached — needs repairing
+git checkout -B main HEAD           # same commit, now on a branch
+```
+
+To find out whether a machine is affected at all, ask lazy.nvim which plugin it cannot
+name a branch for:
+
+```sh
+nvim --headless -c 'lua local G=require("lazy.manage.git") for _,p in pairs(require("lazy.core.config").plugins) do if p._.installed and not p._.is_local then local i=G.info(p.dir) if not i or not (i.branch or G.get_branch(p)) then print("no branch: "..p.name) end end end' -c 'qa!'
+```
+
+> [!NOTE]
+> LazyVim needs NeoVim 0.11 or newer (`modules/editor.sh` pins 0.11.2). Check with
+> `nvim --version`; a `nvim --version` that works proves only that the editor is
+> installed, not that this config is loaded. To check that, run
+> `nvim --headless -c 'lua print(pcall(require, "lazyvim"))' -c 'qa!'`.
+
+
+## Nextcloud upload
+
+`bin/windows/cloud-upload.ps1` uploads files and folders to a Nextcloud instance
+over WebDAV, skipping anything already there. `bin/windows/Setup-Nextcloud.ps1`
+wires it up: credentials, `rclone`, a mapped drive and the Explorer *Send to* entry.
+
+`bin/windows/` sits outside what `modules/scripts.sh` links, for the same reason as
+`configs/powershell/`: `install.sh` cannot run on Windows. Setup points `%USERPROFILE%\bin\cloud-upload.cmd`
+at the repo copy rather than copying the script, so there is only ever one version.
+
+### How to apply
+
+```powershell
+pwsh -ExecutionPolicy Bypass -File "$env:USERPROFILE\workspace\settings\bin\windows\Setup-Nextcloud.ps1"
+```
+
+It prompts for the server URL, user ID and an app password. Nothing it asks for is
+stored in the repo — the server and user land in `~/.cloud-upload.json`, the password
+in `~/_netrc`, both outside the repo because this one is public. Run it from an
+elevated shell to also lift the 50MB WebDAV file size limit.
+
+### Skipping what is already uploaded
+
+Nextcloud exposes no content hash, which is worth stating because it rules out the
+obvious design:
+
+- `d:getetag` is a server-internal value, not a digest of the bytes. An empty file
+  came back as `254b5e60…`, nothing like the MD5 of an empty string.
+- `oc:checksum` is never populated. Uploading with `OC-Checksum: SHA1:…` and then
+  with `MD5:…` both left the property returning 404 (Nextcloud 32.0.3).
+
+Comparing real hashes would mean downloading each remote file, which costs more than
+re-uploading it. So the comparison is size + mtime, the same basis rclone uses:
+
+- One `PROPFIND` with `Depth: infinity` returns the whole remote tree — 200 entries
+  in 62KB, measured at 0.16s. If a server refuses it (Sabre/DAV disables it by
+  default; this instance allows it) the script falls back to per-directory `Depth: 1`.
+- Uploads carry `X-OC-Mtime`, so the remote timestamp is the local one and the next
+  run compares exactly rather than against an upload time.
+- Files predating that header have no matching mtime, so "same size and the remote is
+  newer" also counts as unchanged. For an upload-only workflow that holds: a remote
+  copy written after the local file was last touched has the local content. `-Strict`
+  demands an exact mtime match instead; `-Force` uploads regardless.
+
+Re-running over an unchanged 40-file folder went from 4.6s to 0.31s. Parallel PUTs
+(`curl -Z`) are also on, but they are close to noise here — 6.0s against 6.9s for 60
+small files, with the server's per-request work as the bottleneck. Not transferring
+is where the time goes.
+
+| | |
+| :--- | :--- |
+| `cloud-upload DIR -To sub` | Upload a folder, changed files only |
+| `cloud-upload DIR -DryRun` | List what would be uploaded |
+| `cloud-upload FILE -Share -Expire 7` | Public link to the clipboard, expiring in 7 days |

--- a/lib/cli.sh
+++ b/lib/cli.sh
@@ -29,10 +29,10 @@ get_component_desc() {
         zellij)      echo "zellij (modern terminal multiplexer)" ;;
         rust)        echo "Rust toolchain + cargo-binstall" ;;
         uv)          echo "uv (fast Python package manager)" ;;
-        tools)       echo "CLI tools (eza, fd, ripgrep)" ;;
+        tools)       echo "CLI tools (eza, fd, ripgrep, fzf)" ;;
         tools-extra) echo "Extra CLI tools (delta, dust, procs, bottom)" ;;
         ssh)         echo "SSH config (copy only, not symlinked)" ;;
-        hishtory)    echo "hishtory (better shell history with S3 sync)" ;;
+        hishtory)    echo "hishtory (better shell history with self-hosted sync)" ;;
         hammerspoon) echo "Hammerspoon (macOS-only: window manager + keybindings)" ;;
         ghostty)     echo "Ghostty terminal config (macOS-only: Option-as-Alt so TUI Alt bindings work)" ;;
         codex)       echo "Codex CLI/App config, hooks, and notify chain" ;;

--- a/scripts/tests/cloud-upload-smoke.ps1
+++ b/scripts/tests/cloud-upload-smoke.ps1
@@ -1,0 +1,91 @@
+# Run with pwsh -NoProfile -File scripts/tests/cloud-upload-smoke.ps1.
+# Exercise the full script with fake transports, config and input files.
+$ErrorActionPreference = 'Stop'
+$sourcePath = Join-Path $PSScriptRoot '../../bin/windows/cloud-upload.ps1'
+$tempRoot = Join-Path ([IO.Path]::GetTempPath()) ('cloud-upload-test-' + [guid]::NewGuid())
+$previousProfile = $env:USERPROFILE
+New-Item -ItemType Directory -Path $tempRoot | Out-Null
+try {
+  $env:USERPROFILE = $tempRoot
+  @{ server='https://example.invalid'; user='test'; remoteDir='Uploads' } |
+    ConvertTo-Json | Set-Content (Join-Path $tempRoot '.cloud-upload.json')
+  $folder = New-Item -ItemType Directory -Path (Join-Path $tempRoot 'dist')
+  'a' | Set-Content (Join-Path $folder 'a.txt')
+  'b' | Set-Content (Join-Path $folder 'b.txt')
+  $file = Join-Path $folder 'a.txt'
+
+  # Replace only transport discovery; keep all control flow and request building.
+  $source = Get-Content $sourcePath -Raw
+  $discovery = '(?m)^\$curl = .*\r?\nif \(-not \(Test-Path \$curl\)\) \{[^\r\n]+\}'
+  if ([regex]::Matches($source, $discovery).Count -ne 1) { throw 'Transport discovery changed; update harness.' }
+  $testScript = Join-Path $tempRoot 'upload.ps1'
+  [regex]::Replace($source, $discovery, { '$curl = ''Invoke-MockCurl''' }) | Set-Content $testScript
+
+  $state = @{}
+  function Assert($condition, $message) { if (-not $condition) { throw $message } }
+  function Invoke-MockCurl {
+    $state.requests.Add(@($args))
+    $global:LASTEXITCODE = 0
+    if ($args -contains 'PROPFIND') {
+      $responses = foreach ($f in Get-ChildItem $folder -File) {
+        $mtime = $f.LastWriteTimeUtc.ToString('R', [Globalization.CultureInfo]::InvariantCulture)
+        '<d:response><d:href>/remote.php/dav/files/test/Uploads/dist/' + $f.Name + '</d:href><d:propstat><d:status>HTTP/1.1 200 OK</d:status><d:prop><d:getcontentlength>' + $f.Length + '</d:getcontentlength><d:getlastmodified>' + $mtime + '</d:getlastmodified><d:resourcetype/></d:prop></d:propstat></d:response>'
+      }
+      '<d:multistatus xmlns:d="DAV:">' + ($responses -join '') + '</d:multistatus>'
+      '207'
+    } elseif ($args -contains 'POST') {
+      '{"ocs":{"data":{"url":"https://example.invalid/s/mock"}}}'
+    } elseif ($args -contains '-K') {
+      $config = Get-Content $args[([array]::IndexOf($args, '-K') + 1)]
+      foreach ($line in $config) { if ($line -match '^url = ') { '201' } }
+    } elseif ($args -contains '-T') {
+      if ($state.failUpload) { $global:LASTEXITCODE = 22 }
+    } else { throw "Unexpected curl call: $args" }
+  }
+  function rclone {
+    $global:LASTEXITCODE = 0
+    if ($args[0] -eq 'listremotes') { 'nc:' }
+    else { $state.copies.Add(@($args)) }
+  }
+  function Set-Clipboard { param($Value) $state.clipboard = $Value }
+  function Run-Case($name, $arguments, $expectedShare, $expectedCopies = 0, $dry = $false, $failure = $false) {
+    $state.requests = [Collections.Generic.List[object]]::new()
+    $state.copies = [Collections.Generic.List[object]]::new()
+    $state.clipboard = $null
+    $state.failUpload = $failure
+    $global:LASTEXITCODE = 0
+    & $testScript @arguments | Out-Null
+    $posts = @($state.requests | Where-Object { $_ -contains 'POST' })
+    Assert ($posts.Count -eq [int][bool]$expectedShare) "$name : unexpected share count"
+    if ($expectedShare) {
+      Assert ($posts[0] -contains "path=$expectedShare") "$name : wrong public share scope"
+      Assert ($state.clipboard -eq 'https://example.invalid/s/mock') "$name : missing clipboard link"
+    } else { Assert ($null -eq $state.clipboard) "$name : unexpected clipboard write" }
+    Assert ($state.copies.Count -eq $expectedCopies) "$name : wrong rclone call count"
+    if ($dry) {
+      foreach ($copy in $state.copies) { Assert ($copy -contains '--dry-run') "$name : live rclone transfer" }
+      Assert (@($state.requests | Where-Object { $_ -contains '-T' -or $_ -contains '-K' }).Count -eq 0) "$name : live curl transfer"
+    }
+    Write-Host "PASS: $name"
+  }
+  Run-Case 'folder share' @{ Path=$folder.FullName; Share=$true; Force=$true } '/Uploads/dist'
+  Run-Case 'single file share' @{ Path=$file; Share=$true; Force=$true } '/Uploads/a.txt'
+  Run-Case 'already uploaded folder share' @{ Path=$folder.FullName; Share=$true } '/Uploads/dist'
+  Run-Case 'already uploaded file share' @{ Path=$file; To='Uploads/dist'; Share=$true } '/Uploads/dist/a.txt'
+  Run-Case 'curl dry run with share' @{ Path=$folder.FullName; Share=$true; DryRun=$true; Force=$true } $null 0 $true
+  Run-Case 'already uploaded dry run' @{ Path=$folder.FullName; Share=$true; DryRun=$true } $null 0 $true
+  Run-Case 'sync folder share' @{ Path=$folder.FullName; Share=$true; Sync=$true } '/Uploads/dist' 1
+  Run-Case 'sync file share' @{ Path=$file; Share=$true; Sync=$true } '/Uploads/a.txt' 1
+  Run-Case 'sync dry run with share' @{ Path=$file; Share=$true; Sync=$true; DryRun=$true } $null 1 $true
+  Run-Case 'sync folder dry run with share' @{ Path=$folder.FullName; Share=$true; Sync=$true; DryRun=$true } $null 1 $true
+  Run-Case 'multiple share inputs rejected' @{ Path=(Join-Path $folder '*.txt'); Share=$true; Force=$true } $null
+  Assert ($LASTEXITCODE -eq 1 -and $state.requests.Count -eq 0) 'Multiple inputs must fail before network activity'
+  Run-Case 'failed upload does not share' @{ Path=$file; Share=$true; Force=$true } $null 0 $false $true
+  Assert ($LASTEXITCODE -eq 1) 'Failed upload must return failure'
+} finally {
+  $env:USERPROFILE = $previousProfile
+  $resolved = [IO.Path]::GetFullPath($tempRoot)
+  $tempBase = [IO.Path]::GetFullPath([IO.Path]::GetTempPath()).TrimEnd('\') + '\'
+  if (-not $resolved.StartsWith($tempBase, [StringComparison]::OrdinalIgnoreCase)) { throw 'Unsafe cleanup path' }
+  Remove-Item -LiteralPath $resolved -Recurse -Force
+}


### PR DESCRIPTION
The README is now a 198-line landing page with installation commands, a component overview, platform support, usage, and links to five guides. Detailed Windows setup, PowerShell performance notes, agent restoration, and component-specific manual steps live in `docs/`; the existing tmux-to-zellij guide remains linked.

The component notes preserve hishtory sync configuration, Hammerspoon Accessibility setup, and the managed Codex configuration boundaries. README usage matches `lib/cli.sh`, including Ghostty, fzf, and self-hosted hishtory sync. The platform table distinguishes the Linux/macOS installer from manual Windows setup.

The Windows guide also documents the newly tracked Nextcloud setup and upload scripts. Upload behavior is covered by regression tests:

- `-Share` shares exactly one resolved input file or folder, never its common upload parent. Multiple inputs are rejected before transfers, and failed uploads do not create links. Folder links include existing contents of that remote folder.
- Already-uploaded files and folders can still receive a public link.
- `-Sync -DryRun` passes `--dry-run` to rclone. Neither transfer mode creates public links during a dry run.

Validation:

- 12 full-script regression scenarios pass with mocked curl/rclone and temporary inputs; no real uploads or public shares are created by the tests.
- Both Windows scripts and the regression script parse under PowerShell 7.
- `bash -n lib/cli.sh` and `git diff --check` pass.
- Earlier document checks covered relative links, anchors, and control characters. Visual review of GitHub's rendered diff remains unverified because a connected browser was unavailable.

Run the regression checks with `pwsh -NoProfile -File scripts/tests/cloud-upload-smoke.ps1`.
