### PR TITLE
feat(powershell): mirror the zsh t* session shortcuts on Windows

### DIFF
--- a/configs/powershell/profile.ps1
+++ b/configs/powershell/profile.ps1
@@ -475,6 +475,58 @@ if (Test-Tool rmux) {
     function ra { rmux attach-session -t @args }
     function rl { rmux list-sessions }
     function rx { rmux kill-session -t @args }
+
+    # The t* names from the oh-my-zsh tmux plugin, backed by rmux. This mirrors the
+    # block configs/.zshrc sets up in the same spirit, so the same shortcuts work on
+    # every machine — including `ts` meaning `new-session -s` and `to` meaning
+    # `new-session -A -s`, which is the plugin's split and not an obvious one.
+    #
+    # Both call shapes the plugin accepted: a bare name (`ta work`) gets the name flag
+    # inserted, anything starting with a dash (`ta -t work`) is passed straight through.
+    # Every argument is passed by name. Positionally, PowerShell reads a value like
+    # '-t' as an attempt to name a parameter and the binding fails outright.
+    function Invoke-RmuxSession {
+        param(
+            [string]$Action,
+            [string]$NameFlag,
+            [string]$ExtraFlag,
+            [string[]]$Rest
+        )
+        $argv = @($Action)
+        if ($ExtraFlag) { $argv += $ExtraFlag }
+        if ($Rest -and $Rest.Count -gt 0 -and $Rest[0] -notlike '-*') { $argv += $NameFlag }
+        if ($Rest) { rmux @argv @Rest } else { rmux @argv }
+    }
+
+    function ta   { Invoke-RmuxSession -Action attach-session -NameFlag '-t' -ExtraFlag ''   -Rest $args }
+    function tad  { Invoke-RmuxSession -Action attach-session -NameFlag '-t' -ExtraFlag '-d' -Rest $args }
+    function ts   { Invoke-RmuxSession -Action new-session    -NameFlag '-s' -ExtraFlag ''   -Rest $args }
+    function to   { Invoke-RmuxSession -Action new-session    -NameFlag '-s' -ExtraFlag '-A' -Rest $args }
+    function tkss { Invoke-RmuxSession -Action kill-session   -NameFlag '-t' -ExtraFlag ''   -Rest $args }
+    function tl   { rmux list-sessions @args }
+    function tksv { rmux kill-server @args }
+
+    # tds: one stable session per directory. .zshrc derives the suffix with `cksum`,
+    # which has no PowerShell equivalent worth reimplementing bit-for-bit; sessions are
+    # per-machine anyway, so this uses a truncated MD5 of the path instead. Same
+    # property — same directory, same session — different name than on zsh.
+    function tds {
+        $leaf = Split-Path -Leaf $PWD.Path
+        # At a drive root the leaf is the root itself ("C:\"), and rmux does not reject
+        # a name containing ':' — it silently rewrites it ("C:\-abc" becomes "C_\\-abc"),
+        # leaving a session that `tkss` cannot find under the name you asked for. Reduce
+        # a root to its drive letter and replace anything else rmux would rewrite.
+        if (-not $leaf -or $leaf -match '^[A-Za-z]:\\?$') { $leaf = $PWD.Drive.Name }
+        $leaf = $leaf -replace '[^\w.-]', '_'
+
+        $md5 = [System.Security.Cryptography.MD5]::Create()
+        try {
+            $hash = $md5.ComputeHash([System.Text.Encoding]::UTF8.GetBytes($PWD.Path))
+        } finally { $md5.Dispose() }
+        $digest = -join ($hash[0..3] | ForEach-Object { $_.ToString('x2') })
+
+        rmux new-session -A -s ("{0}-{1}" -f $leaf, $digest)
+    }
 }
 
 ################################


### PR DESCRIPTION
You were right that these come from the oh-my-zsh tmux plugin — and `configs/.zshrc`
already replaced its shortcuts with rmux-backed functions of the same names in
`ac117dd`. The PowerShell profile had invented `rs`/`ra`/`rl`/`rx` instead, so the
shortcuts that exist on every other machine were missing here. This ports that block
rather than approximating it.

| | | | |
| :--- | :--- | :--- | :--- |
| `ta` | `attach-session -t` | `tad` | `attach-session -d -t` |
| `ts` | `new-session -s` | `to` | `new-session -A -s` |
| `tkss` | `kill-session -t` | `tl` | `list-sessions` |
| `tksv` | `kill-server` | `tds` | one stable session per directory |

## Three things the self-review caught

**`ts` was wrong.** The first draft added only `ta`/`ts`/`tl`, with `ts` as
`new-session -A -s` — which is the plugin's `to`, not its `ts`. They are not
interchangeable: `ts` fails if the session exists, `to` attaches to it. Fetching the
plugin source settled it rather than relying on memory.

**Positional binding fails.** Every argument to the helper is passed *by name*:
positionally, PowerShell reads a value like `-t` as an attempt to name a parameter and
binding fails with *"missing mandatory parameters"*.

**`tds` could strand an unkillable session.** At a drive root the path leaf is the root
itself, `C:\`, and rmux does **not** reject a session name containing `:` — it silently
rewrites it. Verified: asking for `C:\-abc1234` produced `C_\-abc1234`, which
`kill-session -t "C:\-abc1234"` then could not find. A root now reduces to its drive
letter and anything else rmux would rewrite becomes `_`:

| cwd | session |
| :--- | :--- |
| `C:\` | `C-2f158c47` |
| `C:\Program Files` | `Program_Files-f32b5f88` |
| `F:\ai` | `ai-85260a46` |

The suffix is a truncated MD5 of the path rather than `.zshrc`'s `cksum`, which has no
PowerShell equivalent worth reimplementing bit-for-bit. Sessions are per-machine, so a
different name than zsh's costs nothing.

## Deliberate differences from .zshrc

- these call `rmux`, not the equivalent of `command rmux`, matching how the rest of this
  profile invokes tools — nothing here defines an `rmux` function to bypass
- session-name completion (`compdef _rmux_session_names`) is not ported; say the word and
  it becomes a `Register-ArgumentCompleter`

## Verified against the running rmux server

- all twelve names (`t*` and `r*`) were free beforehand; `to` is not a reserved word
- every call shape produces the command line `.zshrc` would produce
- `ts alias-probe` created a real session, `tkss alias-probe` removed it
- `tds` at `C:\` created `C-2f158c47`, and `tkss` removed it cleanly
- profile load cost unchanged at ~400ms

`rs`/`ra`/`rl`/`rx` stay for now — nothing depends on them, and removing names is a
separate decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016wukLAEPLBuWkhiFgZ7Xh8