### PR TITLE
fix(powershell): make a multi-line paste over ssh survive

### DIFF
--- a/configs/powershell/profile.ps1
+++ b/configs/powershell/profile.ps1
@@ -107,6 +107,80 @@ if ($script:Interactive) {
     Set-PSReadLineKeyHandler -Key Delete          -Function DeleteChar
     Set-PSReadLineKeyHandler -Key Ctrl+RightArrow -Function ForwardWord
     Set-PSReadLineKeyHandler -Key Ctrl+LeftArrow  -Function BackwardWord
+
+    # Ctrl+Enter — treat it as Enter.
+    #
+    # Windows OpenSSH/ConPTY renders a *pasted* LF as a Ctrl+Enter record
+    # (VK_RETURN, scan 0x1c, U+000A, LEFT_CTRL_PRESSED) rather than Ctrl+J, so every
+    # newline in a paste arrives here as Ctrl+Enter. EditMode Windows binds it to
+    # InsertLineAbove; EditMode Emacs binds nothing, and an unbound key is dropped
+    # without a sound — which is why a multi-line paste over ssh collapsed onto one
+    # line under a multiplexer.
+    #
+    # AcceptLine, because without bracketed paste a pasted newline *is* a newline
+    # typed at the prompt: three pasted lines should run as three commands, which is
+    # what the same paste does outside the multiplexer. AddLine would instead build
+    # one multi-line buffer, and there is no way to tell the two intents apart from
+    # a key record — PSReadLine never learns that a paste is in progress. Incomplete
+    # input still continues to the next line, exactly as Enter does.
+    Set-PSReadLineKeyHandler -Key Ctrl+Enter -Function AcceptLine
+
+    # Alt+V — paste the clipboard of whichever machine the terminal is on.
+    #
+    # PSReadLine has no bracketed paste: the shipped binary contains no ?2004, no
+    # 200~/201~, no OSC 52. So a terminal cannot announce "this is a paste, take it
+    # literally", and a multi-line paste arrives as plain keystrokes whose newlines
+    # become Enter. Locally that never showed, because EditMode Windows binds Ctrl+V
+    # to PSReadLine's own Paste, which reads the clipboard directly and skips the
+    # terminal. EditMode Emacs binds no paste key at all, so over ssh the paste is
+    # whatever the terminal typed for us.
+    #
+    # PSReadLine's Paste would read the clipboard of the box PSReadLine runs on —
+    # the wrong end of an ssh session. OSC 52 asks the terminal instead, which is
+    # the only standard way to reach the client's clipboard. Terminals gate it:
+    # Ghostty needs `clipboard-read = allow`. When nothing answers we fall back to
+    # the local clipboard, which is exactly what Paste would have done.
+    function Get-TerminalClipboard {
+        param([int]$TimeoutMs = 400)
+        if ([Console]::IsInputRedirected) { return $null }
+        while ([Console]::KeyAvailable) { [void][Console]::ReadKey($true) }
+        [Console]::Write("$([char]27)]52;c;?$([char]7)")   # ESC ] 52 ; c ; ? BEL
+
+        $sb = [Text.StringBuilder]::new()
+        $sw = [Diagnostics.Stopwatch]::StartNew()
+        $state = 'wait-esc'
+        while ($sw.ElapsedMilliseconds -lt $TimeoutMs -and $state -ne 'done') {
+            if (-not [Console]::KeyAvailable) { Start-Sleep -Milliseconds 5; continue }
+            $ch = [Console]::ReadKey($true).KeyChar
+            if ($state -eq 'wait-esc') {
+                if ($ch -eq [char]27) { $state = 'in-osc' }
+            } elseif ($ch -eq [char]7) {
+                $state = 'done'
+            } elseif ($ch -eq '\' -and $sb.Length -gt 0 -and $sb[$sb.Length - 1] -eq [char]27) {
+                [void]$sb.Remove($sb.Length - 1, 1); $state = 'done'   # ST
+            } else {
+                [void]$sb.Append($ch)
+            }
+        }
+        if ($state -ne 'done') { return $null }
+
+        $raw = $sb.ToString()                    # ]52;c;<base64>
+        $i = $raw.LastIndexOf(';')
+        if ($i -lt 0) { return $null }
+        try { [Text.Encoding]::UTF8.GetString([Convert]::FromBase64String($raw.Substring($i + 1))) }
+        catch { $null }
+    }
+
+    Set-PSReadLineKeyHandler -Key Alt+v -BriefDescription PasteFromTerminal `
+        -Description 'Paste the terminal-side clipboard (OSC 52), falling back to the local one' `
+        -ScriptBlock {
+            $text = Get-TerminalClipboard
+            if ($null -eq $text) { $text = Get-Clipboard -Raw -ErrorAction SilentlyContinue }
+            if ([string]::IsNullOrEmpty($text)) { return }
+            # Newlines stay newlines: PSReadLine then edits it as a multi-line buffer
+            # instead of running each line, which is the whole point.
+            [Microsoft.PowerShell.PSConsoleReadLine]::Insert(($text -replace "`r`n", "`n" -replace "`r", "`n"))
+        }
 }
 
 ################################

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -112,6 +112,31 @@ wrappers and the Korean two-set prefix policy all carry over.
 > bare-shell baseline, down from 1183ms. The techniques and the numbers are in
 > [powershell.md](powershell.md).
 
+### Pasting over ssh (Alt+V)
+
+Pasting several lines into pwsh over ssh runs them as separate commands, or arrives
+as one line with the newlines gone. The terminal is not at fault — **PSReadLine has
+no bracketed paste**. Scanning the shipped binary (2.4.5) for `?2004`, `200~`,
+`201~`, `BracketedPaste` and `]52;` returns nothing for all five, so a terminal has
+no way to announce "this is a paste, take it literally" and the text arrives as
+ordinary keystrokes whose newlines are Enter.
+
+This never shows locally because `EditMode Windows` binds Ctrl+V to PSReadLine's own
+`Paste`, which reads the clipboard directly and never involves the terminal. This
+profile sets `EditMode Emacs` to match `.zshrc`'s `bindkey -e`, and Emacs mode binds
+no paste key at all — so over ssh you get whatever the terminal typed.
+
+Binding PSReadLine's `Paste` does not fix it either: it reads the clipboard of the
+machine PSReadLine runs on, which over ssh is the far end from the clipboard you
+copied into. `Alt+V` instead asks the *terminal* for its clipboard over OSC 52 and
+inserts the reply with newlines intact, leaving PSReadLine editing a multi-line
+buffer. If nothing answers within 400ms it falls back to the local clipboard, which
+is what `Paste` would have done anyway.
+
+Terminals gate OSC 52 reads. Ghostty needs `clipboard-read = allow`, which
+`configs/ghostty/config` already sets. A terminal that refuses simply takes the
+fallback path.
+
 ## NeoVim
 
 `configs/nvim/` needs no Windows variant — nothing in it is POSIX-specific. What it


### PR DESCRIPTION
## Summary

Pasting several lines into pwsh over ssh either ran them as separate commands or arrived as one line with the newlines gone.

The terminal is not at fault — **PSReadLine has no bracketed paste.** Scanning the shipped binary (2.4.5) for `?2004`, `200~`, `201~`, `BracketedPaste` and `]52;` returns nothing for all five, so a terminal cannot announce "this is a paste, take it literally" and the text arrives as ordinary keystrokes whose newlines are Enter.

It never showed locally because `EditMode Windows` binds Ctrl+V to PSReadLine's own `Paste`, which reads the clipboard directly and skips the terminal. This profile sets `EditMode Emacs` to match `.zshrc`'s `bindkey -e`, and Emacs mode binds no paste key at all.

## Two bindings

**Ctrl+Enter → AcceptLine.** Windows OpenSSH/ConPTY renders a pasted LF as a Ctrl+Enter record (`VK_RETURN`, scan `0x1c`, `U+000A`, `LEFT_CTRL_PRESSED`), not Ctrl+J. Emacs mode binds nothing there and an unbound key is dropped silently — which is how a multi-line paste under a multiplexer collapsed onto one line. `AcceptLine` rather than `AddLine`: without bracketed paste a pasted newline *is* a newline typed at the prompt, and there is no way to tell the two intents apart from a key record.

**Alt+V → OSC 52 paste**, for when you want the paste kept whole. PSReadLine's `Paste` reads the clipboard of the machine PSReadLine runs on — the wrong end of an ssh session. Alt+V asks the *terminal* instead and inserts the reply with newlines intact. Falls back to the local clipboard after 400ms.

Terminals gate OSC 52 reads; Ghostty needs `clipboard-read = allow`, which `configs/ghostty/config` already sets.

## Test plan

- [x] `profile.ps1` parses with 0 errors
- [x] Redirected stdin → the reader returns `null` in **7ms**, not after the 400ms timeout, so a scripted shell pays nothing
- [x] OSC 52 payload round-trip: `line1\nline2 한글` decodes intact (base64 + UTF-8, newline preserved)
- [x] `Set-PSReadLineKeyHandler -Key Alt+v` registers and reports as `PasteFromTerminal`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q9BTTPTqSyEfgcXwGo8mJd